### PR TITLE
Drop use of expanduser in default config

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -13,8 +13,8 @@ deployment:
   keypair:
     -
       name: krakenKey
-      publickeyFile: "{{ '~/.ssh/id_rsa.pub' | expanduser}}"
-      privatekeyFile: "{{ '~/.ssh/id_rsa' | expanduser}}"
+      publickeyFile: "$HOME/.ssh/id_rsa.pub"
+      privatekeyFile: "$HOME/.ssh/id_rsa "
   kubeConfig:
     -
       name: krakenKubeConfig


### PR DESCRIPTION
the existing defaults don't work with k2cli, let's see if this does (and
whether it breaks the non-k2cli case on jenkins?)