### PR TITLE
Move network fabric to kube-networking namespace

### DIFF
--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
@@ -14,6 +14,11 @@
 
 - name: Deploy canal configuration
   command: >
+    kubectl --kubeconfig={{ kubeconfig | expanduser }} create namespace kube-networking
+  ignore_errors: yes
+
+- name: Deploy canal configuration
+  command: >
     kubectl --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{kraken_config.cluster}}/fabric/config.yaml
 
 - name: Deploy canal daemonset

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/canal.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/canal.yaml.part.jinja2
@@ -5,7 +5,7 @@ kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
   name: canal-node
-  namespace: kube-system
+  namespace: kube-networking
   labels:
     k8s-app: canal-node
 spec:
@@ -201,7 +201,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: configure-canal
-  namespace: kube-system
+  namespace: kube-networking
   labels:
     k8s-app: canal
 spec:
@@ -264,7 +264,7 @@ apiVersion: extensions/v1beta1
 kind: ReplicaSet
 metadata:
   name: calico-policy-controller
-  namespace: kube-system
+  namespace: kube-networking
   labels:
     k8s-app: calico-policy
 spec:
@@ -273,7 +273,7 @@ spec:
   template:
     metadata:
       name: calico-policy-controller
-      namespace: kube-system
+      namespace: kube-networking
       labels:
         k8s-app: calico-policy
     spec:

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/config.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/config.yaml.part.jinja2
@@ -5,7 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: canal-config
-  namespace: kube-system
+  namespace: kube-networking
 data:
   # Configure this with the location of your etcd cluster.
   etcd_endpoints: "{% if kraken_config.master.infra.etcd.ssl == true %}https{% else %}http{% endif %}://{{kraken_config.master.infra.etcd.name}}.{{kraken_config.cluster}}.internal:{{kraken_config.master.infra.etcd.clientPorts[0]}}"


### PR DESCRIPTION
There was an ask to move network fabric stuff to its own namespace because of conformance tests having issues with jobs