### PR TITLE
Correcting the SSL directory

### DIFF
--- a/ansible/roles/kraken.master/kraken.master.docker/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.master/kraken.master.docker/templates/api-server-manifest.yaml.jinja2
@@ -48,7 +48,7 @@ spec:
     - mountPath: /etc/etcd/ssl
       name: ssl-certs-etcd
       readOnly: true
-    - mountPath: /etc/ssl
+    - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
   volumes:


### PR DESCRIPTION
for some reason this didn't matter in versions <= 1.4

Tested by hand on a 1.5 hyperkube cluster