### PR TITLE
Support oidc auth using dex.

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -21,6 +21,7 @@ deployment:
       version: v1.4.4
       hyperkubeLocation: gcr.io/google_containers/hyperkube
       containerConfig: dockerconfig
+  kubeAuth:
   containerConfig:
     -
       name: dockerconfig

--- a/ansible/roles/kraken.config/tasks/main.yml
+++ b/ansible/roles/kraken.config/tasks/main.yml
@@ -62,5 +62,8 @@
      (kraken_config.resourcePrefix is none) or 
      (kraken_config.resourcePrefix|trim == '')"
 
-#- name: Display config
-#  debug: var=kraken_config
+- include: set-oidc-info.yaml
+  when: "kraken_config.kubeAuth.oidc is defined"
+
+  #- name: Display config
+  #  debug: var=kraken_config

--- a/ansible/roles/kraken.config/tasks/set-oidc-info.yaml
+++ b/ansible/roles/kraken.config/tasks/set-oidc-info.yaml
@@ -4,9 +4,35 @@
   with_items: "{{ kraken_config.clusterServices.services | default([]) }}"
   when: item.name == "{{ kraken_config.kubeAuth.oidc.service_name }}"
 
+## TO DO :
+# Here duplicated oidc issuer configuration.
+# To support various oidc provider ( CoreOS Dex, Redhat Keycloak, CF UAA ),
+# it would better to makes a abstraction layer.
+# it will dynamically retrive oidc configuration from given cluster service (ex: Dex, keycloak, UAA)
+#
+# kraken_config:
+#   kubeAuth:
+#     oidc:
+#       service_name: dex
+#       issuer: https://dex.my.cluster.io:8443
+#       domain: dex.my.cluster.io
+#
+# ...
+#
+#   clusterServices:
+#     services:
+#       - 
+#         name: dex
+#         values:
+#           Dex: 
+#             Issuer: https://dex.my.cluster.io:8443
+# ...
+#
+
 - name: Retrieve issuer URL
   set_fact: 
     oidc_issuer: "{{ oidc_provider_values.Dex.Issuer }}"
+
 
 - name: Retrieve domain value from 
   shell: "echo {{ oidc_issuer  }} | awk -F/ '{print $3}' | awk -F: '{print $1}'"
@@ -23,3 +49,4 @@
         }
       }
     } )}}"
+

--- a/ansible/roles/kraken.config/tasks/set-oidc-info.yaml
+++ b/ansible/roles/kraken.config/tasks/set-oidc-info.yaml
@@ -1,0 +1,25 @@
+- name: Get oidc provider values from cluster services
+  set_fact:
+    oidc_provider_values: "{{ item.get('values') }}"
+  with_items: "{{ kraken_config.clusterServices.services | default([]) }}"
+  when: item.name == "{{ kraken_config.kubeAuth.oidc.service_name }}"
+
+- name: Retrieve issuer URL
+  set_fact: 
+    oidc_issuer: "{{ oidc_provider_values.Dex.Issuer }}"
+
+- name: Retrieve domain value from 
+  shell: "echo {{ oidc_issuer  }} | awk -F/ '{print $3}' | awk -F: '{print $1}'"
+  register: oidc_domain
+
+- name: Set oidc values to kraken_config.kubeAuth
+  set_fact:
+    kraken_config: "{{ kraken_config | combine(
+    {
+      'kubeAuth':{
+        'oidc':{
+          'issuer': oidc_issuer,
+          'domain': oidc_domain.stdout 
+        }
+      }
+    } )}}"

--- a/ansible/roles/kraken.master/kraken.master.docker/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.master/kraken.master.docker/templates/api-server-manifest.yaml.jinja2
@@ -31,6 +31,13 @@ spec:
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --cloud-provider={{kraken_config.kubernetes_cloudprovider}}
     - --logtostderr=true
+{% if kraken_config.kubeAuth.oidc is defined %}
+    - --oidc-issuer-url={{kraken_config.kubeAuth.oidc.issuer}}
+    - --oidc-client-id=example-app
+    - --oidc-ca-file=/etc/kubernetes/ssl/ca.pem
+    - --oidc-username-claim=email
+    - --oidc-groups-claim=groups
+{% endif %}
     ports:
     - containerPort: 443
       hostPort: 443

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -126,6 +126,22 @@ resource "aws_elb" "master_elb" {
     lb_protocol = "tcp"
   }
 
+{% if kraken_config.kubeAuth.oidc is defined %}
+  listener {
+    instance_port = 30443
+    instance_protocol = "tcp"
+    lb_port = 30443
+    lb_protocol = "tcp"
+  }
+
+  listener {
+    instance_port = 30080
+    instance_protocol = "tcp"
+    lb_port = 30080
+    lb_protocol = "tcp"
+  }
+{% endif %}
+
   health_check {
     healthy_threshold = 2
     unhealthy_threshold = 10
@@ -147,6 +163,16 @@ resource "aws_route53_record" "master_record" {
   ttl = "300"
   records = ["${aws_elb.master_elb.dns_name}"]
 }
+
+{% if kraken_config.kubeAuth.oidc is defined %}
+resource "aws_route53_record" "dex_record" {
+  zone_id = "${var.route53_zone_id}"
+  name = "dex.${var.master_name}.kube.cluster.io"
+  type = "CNAME"
+  ttl = "300"
+  records = ["${aws_elb.master_elb.dns_name}"]
+}
+{% endif %}
 
 {% else %}
 # Launch configuration for master loadbalancer

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -167,7 +167,7 @@ resource "aws_route53_record" "master_record" {
 {% if kraken_config.kubeAuth.oidc is defined %}
 resource "aws_route53_record" "dex_record" {
   zone_id = "${var.route53_zone_id}"
-  name = "dex.${var.master_name}.kube.cluster.io"
+  name = "{{ kraken_config.kubeAuth.oidc.domain }}"
   type = "CNAME"
   ttl = "300"
   records = ["${aws_elb.master_elb.dns_name}"]

--- a/ansible/roles/kraken.services/tasks/generate-oidc-cert.yaml
+++ b/ansible/roles/kraken.services/tasks/generate-oidc-cert.yaml
@@ -1,0 +1,47 @@
+---
+- name: Generate dex key
+  command: >
+    openssl genrsa -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex-key.pem 2048
+
+- name: Generate dex csr
+  command: >
+    openssl req -new -key {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex-key.pem
+      -subj "/CN={{ kraken_config.kubeAuth.oidc.domain }}" -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex.csr
+
+- name: Generate dex pem
+  command: >
+    openssl x509 -req -in {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex.csr
+      -CA {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.pem
+        -CAkey {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca-key.pem
+          -CAcreateserial -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex.pem -days 10000
+
+- name: Generate dex service Tls.Ca
+  set_fact:
+    dex_tls_ca: "{{ lookup('file', config_base + '/' + kraken_config.cluster + '/certs/ca.pem' | expanduser) | b64encode }}"
+
+- name: Generate dex service Tls.Cert
+  set_fact:
+    dex_tls_cert: "{{ lookup('file', config_base + '/' + kraken_config.cluster + '/certs/dex.pem' | expanduser) | b64encode }}"
+
+- name: Generate dex service Tls.Key
+  set_fact:
+    dex_tls_key: "{{ lookup('file', config_base + '/' + kraken_config.cluster + '/certs/dex-key.pem' | expanduser) | b64encode }}"
+
+- name: Retrive dex service from cluster services
+  set_fact:
+    dex_service: "{{ cluster_services | selectattr('name', 'match', '^dex$') | first }}"
+
+- name: Remove the dex service from cluster services
+  set_fact:
+    cluster_services: "{{ cluster_services | difference( [ dex_service ] )}}"
+
+- name: Create default TLS values to dex service
+  set_fact:
+    dex_service: "{{ dex_service | combine( {'values':{'Dex':{'Tls':{'Ca': dex_tls_ca,'Cert': dex_tls_cert,'Key': dex_tls_key }}}}, recursive=True ) }}"
+
+- name: Merge dex modified dex service to cluster services
+  set_fact:
+    cluster_services: "{{ cluster_services + [ dex_service ] }}"
+
+- name: Display Service Configuration
+  debug: var=cluster_services

--- a/ansible/roles/kraken.services/tasks/main.yml
+++ b/ansible/roles/kraken.services/tasks/main.yml
@@ -14,6 +14,9 @@
   set_fact:
     cluster_namespaces: "{{ kraken_config.clusterServices.namespaces | default([]) }}"
 
+- include: generate-oidc-cert.yaml
+  when: (kraken_config.kubeAuth.oidc is defined) and (kraken_action == 'up')
+
 - name: See if tiller rc if present
   shell: >
     kubectl --kubeconfig={{ kubeconfig }} get deployment {{ tiller }} --namespace=kube-system

--- a/ansible/roles/kraken.services/templates/service-values.yaml.jinja2
+++ b/ansible/roles/kraken.services/templates/service-values.yaml.jinja2
@@ -1,6 +1,4 @@
 ---
 {% if 'values' in item %}
-{% for key, value in item['values'].iteritems() %}
-{{ key }}: {{ value }}
-{% endfor %}
+{{ item['values'] | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
default, it disabled
to use
need to define 
```
kraken_config:
  kubeAuth:
   oidc:
     service_name: dex
```

also dex service
```
      -
        name: dex
        repo: atlas
        chart: dex
        version: 0.1.0
        namespace: kube-system
        values:
          Dex:
            Issuer: https://dex.keyolk.kube.cluster.io:30443
            Connector:
              Google:
                ClientId: ODc2MDc2NjM5NDQ0LW8zdTIzZjY5ZGlsdXMxYTBkNzd0ZHQxb3FzMWZpaDViLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29t
                ClientSecret: T0pMc0FLeUpsY2ZjaUtnbkhzaHVwZjQ4
          DexApp:
            RedirectUri: http://dex.keyolk.kube.cluster.io:30080/callback
```

one of ugly thing that
I didnt found proper way to
get oidc configuration from service values.
like issuer url and redirect url : (

may we can use another oidc provider
so the object 'kubeAuth.oidc' should dynamically get proper value from given service values.

