### PR TITLE
Add documentation to clarify file paths

### DIFF
--- a/Documentation/kraken-configs/deployments/aws.md
+++ b/Documentation/kraken-configs/deployments/aws.md
@@ -42,7 +42,7 @@
 | --- | --- | --- | --- |
 | accessKey | Optional | String | AWS secret key ID. Default is picked up from standart AWS evironment variables |
 | accessSecret | Optional | String | AWS secret. Default is picked up from standart AWS evironment variables |
-| credentialsFile | Optional | String | This is the path to the shared credentials file. If this is not set and a profile is specified, ~/.aws/credentials will be used. |
+| credentialsFile | Optional | String | This is the path to the shared credentials file. If this is not set and a profile is specified, ${HOME}/.aws/credentials will be used. |
 | credentialsProfile | Optional | String | AWS credentials profile |
 
 ## cert options

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ Earlier, you copied a sample cluster configuration over into `~/.kraken`.  Pleas
 
 You may prefer to save it with a name that is consistent with the `cluster` variable in the configuration. In other words, if your `cluster` is `foo`, then perhaps your file should be named `foo.yaml`
 
+> Note that file paths within the configuration file must be relative to any docker mapping used when running the k2 container. 
+> For example `credentialsFile: /root/.aws/credentials` to use `~/.aws/credentials` when running the container with `-v ~/:/root`.
+
 ### Important configuration variables to adjust
 
 While all configuration options are available for a reason, some are more important than others.  Some key ones include


### PR DESCRIPTION
Add documentation to clarify the expectation that file paths must be
reachable via the mapped volume within the docker container.

Fixes #128