### PR TITLE
updates to deal with new conformance tests

### DIFF
--- a/ansible/roles/kraken.node/kraken.node.docker/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.node/kraken.node.docker/templates/units.kubelet.part.jinja2
@@ -45,7 +45,6 @@
       --allow-privileged=true \
       --config=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
-      --hostname-override=${DEFAULT_IPV4} \
       --cluster-dns={{kraken_config.serviceDNS}} \
       --cluster-domain={{kraken_config.clusterDomain}} \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
@@ -25,7 +25,7 @@ resource "aws_route53_zone" "private_zone" {
 
 # DHCP options sets
 resource "aws_vpc_dhcp_options" "vpc_dhcp" {
-  domain_name         = "${var.vpc_name}.internal"
+  domain_name         = "ec2.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
 
   tags {


### PR DESCRIPTION
please see: https://github.com/samsung-cnct/k2/issues/159 for a full
description

tl;dr there's a bug that means we need to set the vpc domain to be
'ec2.internal' and not override the hostname.  its a combo between
the aws provider and some new e2e tests.