### PR TITLE
Prevent k2 from stomping on user files

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-certs-generate.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-certs-generate.yaml
@@ -29,6 +29,7 @@
       -CA {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.pem
       -CAkey {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca-key.pem
       -CAcreateserial
+      -CAserial {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.srl
       -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/apiserver-loadbalancer.pem
       -days 3650 -extensions v3_req
       -extfile {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/apiserver-loadbalancer-ssl-certificate-options.conf

--- a/ansible/roles/kraken.readiness/tasks/generate-admin-cert.yaml
+++ b/ansible/roles/kraken.readiness/tasks/generate-admin-cert.yaml
@@ -14,5 +14,7 @@
   command: >
     openssl x509 -req -in {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/end-user.csr 
       -CA {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.pem
-        -CAkey {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca-key.pem
-          -CAcreateserial -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/end-user.crt -days 10000 
+      -CAkey {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca-key.pem
+      -CAcreateserial 
+      -CAserial {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.srl
+      -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/end-user.crt -days 10000 

--- a/ansible/roles/kraken.services/tasks/generate-oidc-cert.yaml
+++ b/ansible/roles/kraken.services/tasks/generate-oidc-cert.yaml
@@ -12,8 +12,10 @@
   command: >
     openssl x509 -req -in {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex.csr
       -CA {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.pem
-        -CAkey {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca-key.pem
-          -CAcreateserial -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex.pem -days 10000
+      -CAkey {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca-key.pem
+      -CAcreateserial 
+      -CAserial={{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/ca.srl
+      -out {{ config_base | expanduser }}/{{kraken_config.cluster}}/certs/dex.pem -days 10000
 
 - name: Generate dex service Tls.Ca
   set_fact:

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -44,10 +44,10 @@ function show_help {
 
   inf "\nFor example:"
   inf "[up].sh --generate"
-  inf "[up].sh --generate ~/.kraken/myconfig.yaml"
+  inf "[up].sh --generate \${HOME}/.kraken/myconfig.yaml"
   inf ""
-  inf "[up].sh --output ~/.kraken/myclusterstate --config ~/.kraken/myclusterconfig.yaml --tags config,services"
-  inf "[up].sh --config ~/.kraken/myclusterconfig.yaml"
+  inf "[up].sh --output \${HOME}/.kraken/myclusterstate --config \${HOME}/.kraken/myclusterconfig.yaml --tags config,services"
+  inf "[up].sh --config \${HOME}/.kraken/myclusterconfig.yaml"
 }
 
 function show_post_cluster {
@@ -116,13 +116,13 @@ if [ -n "${KRAKEN_GENERATE_PATH+x}" ]; then
 fi
 
 if [ -z ${KRAKEN_CONFIG+x} ]; then
-  warn "--config not specified. Using ~/.kraken/config.yaml as location"
-  KRAKEN_CONFIG="~/.kraken/config.yaml"
+  warn "--config not specified. Using ${HOME}/.kraken/config.yaml as location"
+  KRAKEN_CONFIG="${HOME}/.kraken/config.yaml"
 fi
 
 if [ -z ${KRAKEN_BASE+x} ]; then
-  warn "--output not specified. Using ~/.kraken as location"
-  KRAKEN_BASE="~/.kraken"
+  warn "--output not specified. Using ${HOME}/.kraken as location"
+  KRAKEN_BASE="${HOME}/.kraken"
 fi
 
 if [ -z ${KRAKEN_TAGS+x} ]; then

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -130,3 +130,6 @@ if [ -z ${KRAKEN_TAGS+x} ]; then
 fi
 
 KRAKEN_EXTRA_VARS="config_path=${KRAKEN_CONFIG} config_base=${KRAKEN_BASE} "
+
+# We don't want anything else to think home is someplace we should write to. Change it.
+export HOME=$(mktemp -d)

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -10,6 +10,9 @@ my_dir=$(dirname "${BASH_SOURCE}")
 readonly KRAKEN_ROOT=$(cd "${my_dir}/.."; pwd)
 KRAKEN_VERBOSE=${KRAKEN_VERBOSE:-false}
 
+# set RANDFILE to prevent creation of ${HOME}/.rnd by openssl
+export RANDFILE=$(mktemp)
+
 function warn {
   echo -e "\033[1;33mWARNING: $1\033[0m"
 }


### PR DESCRIPTION
Move most temporary configuration paths out of `$HOME` or moved files we want to keep to the `--output` path.

Tested by setting `HOME` to a read-only path with no access errors.

Fixes #97