### PR TITLE
Update default k2 config to use k8s 1.5.2 required by latest helm

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -18,7 +18,7 @@ deployment:
   kubeConfig:
     -
       name: krakenKubeConfig
-      version: v1.4.4
+      version: v1.5.2
       hyperkubeLocation: gcr.io/google_containers/hyperkube
       containerConfig: dockerconfig
   containerConfig:


### PR DESCRIPTION
charts.