### PR TITLE
Don't use temporary directory for $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/samsung_cnct/k2/status "Docker Repository on Quay")](https://quay.io/repository/samsung_cnct/k2)
 
+Please use [k2cli](https://github.com/samsung-cnct/k2cli), the intended user interface to K2. The 
+following instructions are intended for developers working on K2.
+
 ## What is K2
 K2 is an orchestration and cluster level management system for [Kubernetes](https://kubernetes.io). K2 will create a production scale Kubernetes
 cluster on a range of platforms using its default settings. This can be especially useful if you are getting
@@ -26,9 +29,6 @@ K2 also supports a number of Samsung CNCT supported addons in the form of Kubern
 These charts are tested and maintained by Samsung CNCT. They should work on any Kubernetes cluster.  
 
 # Getting Started with K2
-The easiest and best supported way to use K2 is through the [K2Cli](https://github.com/samsung-cnct/k2cli).  This cli wraps the K2 image in a tool that is easy to use and configure.
-
-If you want to use the K2 image directly, please continue with this guide.
 
 ## Prerequisites
 
@@ -73,13 +73,29 @@ The easiest way to get started with K2 directly is to use a K2 container image
 
 ## Preparing the environment  
 
+Configure a volume environment variable for use below. Ensure that each of these files or directories exist:
+
+```
+KRAKEN=${HOME}/.kraken          # This is the default output directory for K2
+SSH_KEY=${HOME}/.ssh/id_rsa     # This is the default rsa key configured
+SSH_PUB=${HOME}/.ssh/id_rsa.pub
+AWS_CONFIG=${HOME}/.aws/conifg  # Use these files when using the aws provider
+AWS_CREDENTIALS=${HOME}/.aws/credentials
+K2OPTS="-v ${KRAKEN}:/root/.kraken 
+        -v ${SSH_KEY}:/root/.ssh/id_rsa 
+        -v ${SSH_PUB}:/root/.ssh/id_rsa.pub
+        -v ${AWS_CONFIG}:/root/.aws/config
+        -v ${AWS_CREDENTIALS}:/root/.aws/credentials
+        --rm=true
+        -it"
+
 ### Initial K2 Directory
 If this is your first time using K2, use the K2 Docker image to generate a 'sensible defaults' configuration (this assumes AWS is the infrastructure provider):
 
 With the Docker container:
 
 ```bash
-docker run -v ~:/root --rm=true -it quay.io/samsung_cnct/k2:latest ./up.sh --generate
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --generate
 ```
 
 With the cloned repo:
@@ -91,7 +107,7 @@ With the cloned repo:
 This will generate a config.yaml file located at
 
 ```
-~/.kraken/config.yaml
+${KRAKEN}/config.yaml
 ```
 
 ### Preparing AWS credentials
@@ -103,7 +119,7 @@ To configure the environment with your AWS credentials, run one of the following
 using a Docker container:
 
 ```bash
-docker run -v ~/:/root -it --rm=true quay.io/samsung_cnct/k2:latest bash -c 'aws configure'
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest bash -c 'aws configure'
 ```
 
 using the local awscli tool:
@@ -117,7 +133,7 @@ using the local awscli tool:
 To use the kubectl shipped with K2, run a command similar to:
 
 ```bash
-docker run -v ~/:/root -it --rm=true quay.io/samsung_cnct/k2:latest kubectl --kubeconfig /root/.kraken/YOURCLUSTER/admin.kubeconfig get nodes
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig /root/.kraken/YOURCLUSTER/admin.kubeconfig get nodes
 ```
 
 with locally installed kubectl:
@@ -131,7 +147,7 @@ with locally installed kubectl:
 To use the helm shipped with K2, run a command similar to:
 
 ```bash
-docker run -v ~/:/root -it --rm=true -e HELM_HOME=/root/.kraken/YOURCLUSTER/.helm -e KUBECONFIG=/root/.kraken/YOURCLUSTER/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm list
+docker run $K2OPTS -e HELM_HOME=/root/.kraken/YOURCLUSTER/.helm -e KUBECONFIG=/root/.kraken/YOURCLUSTER/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm list
 ```
 
 with locally installed kubectl:
@@ -219,7 +235,7 @@ For a detailed explanation of all configuration variables, please consult [our c
 To boot up a cluster per your configuration, please execute the following command:
 
 ```bash
-docker run --rm=true -it -v ~/:/root quay.io/samsung_cnct/k2:latest ./up.sh --config /root/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config /root/.kraken/foo.yaml
 ```
 
 Replace `foo.yaml` with the name of the configuration file you intended to use
@@ -239,7 +255,7 @@ You will need to change `cluster` configuration value from `foo` to the value sp
 #### Getting Kubernetes Nodes
 
 ```bash
-docker run -v ~/:/root -it --rm=true quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig get nodes
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig get nodes
 ```
 
 The result should resemble the following:
@@ -259,7 +275,7 @@ ip-10-0-65-77.us-west-2.compute.internal     Ready                      2m
 #### Getting Kubernetes Deployments
 
 ```bash
-docker run -v ~/:/root -it --rm=true quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig get deployments --all-namespaces
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig get deployments --all-namespaces
 ```
 
 ```bash
@@ -277,7 +293,7 @@ You can try having helm install a new service, such as the Kubernetes dashboard
 ##### Find Kubernetes Dashboard Version
 
 ```bash
-docker run -v ~/:/root -it --rm=true -e HELM_HOME=/root/.kraken/foo/.helm -e KUBECONFIG=/root/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes
+docker run $K2OPTS -e HELM_HOME=/root/.kraken/foo/.helm -e KUBECONFIG=/root/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes
 
 $ atlas/kubernetes-dashboard-0.1.0.tgz
 ```
@@ -287,7 +303,7 @@ This indicates that the file to install is `atlas/kubernetes-dashboard-0.1.0`.
 ##### Install Kubernetes Dashboard
 
 ```bash
-docker run -v ~/:/root -it --rm=true -e HELM_HOME=/root/.kraken/foo/.helm -e KUBECONFIG=/root/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install atlas/kubernetes-dashboard-0.1.0
+docker run $K2OPTS -e HELM_HOME=/root/.kraken/foo/.helm -e KUBECONFIG=/root/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install atlas/kubernetes-dashboard-0.1.0
 ```
 
 ```bash
@@ -312,7 +328,7 @@ The chart has been installed. It will take a moment for AWS ELB DNS to propagate
 ##### Finding DNS name for Kubernetes Dashboard
 
 ```bash
-docker run -v ~/:/root -it --rm=true quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig describe service kubernetes-dashboard --namespace kube-system
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig describe service kubernetes-dashboard --namespace kube-system
 ```
 
 ```bash
@@ -374,7 +390,7 @@ In order to effect these changes, make appropriate adjustments to the configurat
 In other words:
 
 ```bash
-docker run --rm=true -it -v ~/:/root quay.io/samsung_cnct/k2:latest ./up.sh --config /root/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config /root/.kraken/foo.yaml
 ```
 
 Replace `foo.yaml` with the name of the configuration file you intend to use.
@@ -384,7 +400,7 @@ Replace `foo.yaml` with the name of the configuration file you intend to use.
 How zen of you - everything must come to end, including Kubernetes clusters. To destroy a cluster created with K2, please do the following:
 
 ```bash
-docker run --rm=true -it -v ~/:/root quay.io/samsung_cnct/k2:latest ./down.sh --config /root/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./down.sh --config /root/.kraken/foo.yaml
 ```
 
 Replace `foo.yaml` with the name of the configuration file you intended to use

--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ SSH_KEY=${HOME}/.ssh/id_rsa     # This is the default rsa key configured
 SSH_PUB=${HOME}/.ssh/id_rsa.pub
 AWS_CONFIG=${HOME}/.aws/conifg  # Use these files when using the aws provider
 AWS_CREDENTIALS=${HOME}/.aws/credentials
-K2OPTS="-v ${KRAKEN}:/root/.kraken 
-        -v ${SSH_KEY}:/root/.ssh/id_rsa 
-        -v ${SSH_PUB}:/root/.ssh/id_rsa.pub
-        -v ${AWS_CONFIG}:/root/.aws/config
-        -v ${AWS_CREDENTIALS}:/root/.aws/credentials
+K2OPTS="-v ${KRAKEN}:${KRAKEN}
+        -v ${SSH_KEY}:${SSH_KEY}
+        -v ${SSH_PUB}:${SSH_PUB}
+        -v ${AWS_CONFIG}:${AWS_CONFIG}
+        -v ${AWS_CREDENTIALS}:${AWS_CREDENTIALS}
+        -e HOME=${HOME}
         --rm=true
         -it"
 
@@ -133,7 +134,7 @@ using the local awscli tool:
 To use the kubectl shipped with K2, run a command similar to:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig /root/.kraken/YOURCLUSTER/admin.kubeconfig get nodes
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig $HOME/.kraken/YOURCLUSTER/admin.kubeconfig get nodes
 ```
 
 with locally installed kubectl:
@@ -147,7 +148,7 @@ with locally installed kubectl:
 To use the helm shipped with K2, run a command similar to:
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=/root/.kraken/YOURCLUSTER/.helm -e KUBECONFIG=/root/.kraken/YOURCLUSTER/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm list
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/YOURCLUSTER/.helm -e KUBECONFIG=$HOME/g.kraken/YOURCLUSTER/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm list
 ```
 
 with locally installed kubectl:
@@ -211,9 +212,6 @@ Earlier, you copied a sample cluster configuration over into `~/.kraken`.  Pleas
 
 You may prefer to save it with a name that is consistent with the `cluster` variable in the configuration. In other words, if your `cluster` is `foo`, then perhaps your file should be named `foo.yaml`
 
-> Note that file paths within the configuration file must be relative to any docker mapping used when running the k2 container. 
-> For example `credentialsFile: /root/.aws/credentials` to use `~/.aws/credentials` when running the container with `-v ~/:/root`.
-
 ### Important configuration variables to adjust
 
 While all configuration options are available for a reason, some are more important than others.  Some key ones include
@@ -235,7 +233,7 @@ For a detailed explanation of all configuration variables, please consult [our c
 To boot up a cluster per your configuration, please execute the following command:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config /root/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/foo.yaml
 ```
 
 Replace `foo.yaml` with the name of the configuration file you intended to use
@@ -293,7 +291,7 @@ You can try having helm install a new service, such as the Kubernetes dashboard
 ##### Find Kubernetes Dashboard Version
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=/root/.kraken/foo/.helm -e KUBECONFIG=/root/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/foo/.helm -e KUBECONFIG=$HOME/g.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes
 
 $ atlas/kubernetes-dashboard-0.1.0.tgz
 ```
@@ -303,7 +301,7 @@ This indicates that the file to install is `atlas/kubernetes-dashboard-0.1.0`.
 ##### Install Kubernetes Dashboard
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=/root/.kraken/foo/.helm -e KUBECONFIG=/root/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install atlas/kubernetes-dashboard-0.1.0
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/foo/.helm -e KUBECONFIG=$HOME/g.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install atlas/kubernetes-dashboard-0.1.0
 ```
 
 ```bash
@@ -390,7 +388,7 @@ In order to effect these changes, make appropriate adjustments to the configurat
 In other words:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config /root/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/foo.yaml
 ```
 
 Replace `foo.yaml` with the name of the configuration file you intend to use.
@@ -400,7 +398,7 @@ Replace `foo.yaml` with the name of the configuration file you intend to use.
 How zen of you - everything must come to end, including Kubernetes clusters. To destroy a cluster created with K2, please do the following:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./down.sh --config /root/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./down.sh --config $HOME/.kraken/foo.yaml
 ```
 
 Replace `foo.yaml` with the name of the configuration file you intended to use

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -58,6 +58,7 @@ deployment:
     resourcePrefix:
     vpc: 10.0.0.0/16
     region: us-west-2
+    configFile: "$HOME/.aws/config"
     subnet:
       -
         name: uwswest2a
@@ -90,7 +91,7 @@ deployment:
     authentication:
       accessKey:
       accessSecret:
-      credentialsFile:
+      credentialsFile: "$HOME/.aws/credentials"
       credentialsProfile:
     ingressSecurity:
       -

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -14,7 +14,7 @@ deployment:
     -
       name: krakenKey
       publickeyFile: "$HOME/.ssh/id_rsa.pub"
-      privatekeyFile: "$HOME/.ssh/id_rsa "
+      privatekeyFile: "$HOME/.ssh/id_rsa"
   kubeConfig:
     -
       name: krakenKubeConfig

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
@@ -15,7 +15,8 @@
 - name: Ensure the kube-networking namespace exists
   command: >
     kubectl --kubeconfig={{ kubeconfig | expanduser }} create namespace kube-networking
-  ignore_errors: yes
+  retries: 120
+  delay: 1
 
 - name: Deploy canal configuration
   command: >

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -42,6 +42,8 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+  retries: 60 
+  delay: 1
 
 - name: Give tiller rc a chance to fully init
   pause: seconds=60

--- a/ansible/roles/kraken.ssh/kraken.ssh.aws/tasks/main.yml
+++ b/ansible/roles/kraken.ssh/kraken.ssh.aws/tasks/main.yml
@@ -1,15 +1,16 @@
 ---
 - name: Gather inventory of all cluster nodes
   ec2_remote_facts:
-    region: "{{kraken_config.providerConfig.region}}"
-    aws_access_key: "{{kraken_config.providerConfig.authentication.accessKey}}"
-    aws_secret_key: "{{kraken_config.providerConfig.authentication.accessSecret}}"
+    region: "{{ kraken_config.providerConfig.region }}"
+    aws_access_key: "{{ kraken_config.providerConfig.authentication.accessKey or omit}}"
+    aws_secret_key: "{{ kraken_config.providerConfig.authentication.accessSecret or omit }}"
+    profile: "{{ kraken_config.providerConfig.authentication.credentialsProfile or omit }}"
     filters:
-      "tag:k2-nodepool": "{{item.name}}"
-      "tag:Name": "{{kraken_config.cluster}}_{{kraken_config.resourcePrefix}}_{{item.name}}*"
-  with_items: "{{kraken_config.nodepool}}"
+      "tag:k2-nodepool": "{{ item.name }}"
+      "tag:Name": "{{ kraken_config.cluster }}_{{ kraken_config.resourcePrefix }}_{{ item.name }}*"
+  with_items: "{{ kraken_config.nodepool }}"
   register: ec2_results
 
 - name: Generate ssh inventory
   template: src=ssh_config.jinja2
-    dest="{{ config_base | expanduser }}/{{kraken_config.cluster}}/ssh_config"
+    dest="{{ config_base | expanduser }}/{{ kraken_config.cluster }}/ssh_config"

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -130,6 +130,3 @@ if [ -z ${KRAKEN_TAGS+x} ]; then
 fi
 
 KRAKEN_EXTRA_VARS="config_path=${KRAKEN_CONFIG} config_base=${KRAKEN_BASE} "
-
-# We don't want anything else to think home is someplace we should write to. Change it.
-export HOME=$(mktemp -d)


### PR DESCRIPTION
Revert `mkdir -d` substitution for $HOME

Document how to map the needed files instead of $HOME
    
Add documentation to the README.md for binding just the files we need
for K2 instead of the entire home directory. This prevents the K2
processes from writing potentially overwriting files in the user's home
directory when running as a container.
    
Fixes #181 and is associated with #97
    
Similar changes to k2cli should be done, https://github.com/samsung-cnct/k2cli/issues/51
