### PR TITLE
Check if the kube-networking namespace exists

### DIFF
--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
@@ -32,6 +32,19 @@
   retries: 120
   delay: 1
   when: not kube_networking_namespace.rc == 0
+  ignore_errors: yes
+
+- name: check kube-networking namespace state
+  command: >  
+    kubectl --kubeconfig={{ kubeconfig | expanduser }} get namespace kube-networking
+  ignore_errors: yes
+  changed_when: false
+  register: kube_networking_namespace
+
+- name: Confirm kube-networking namespace created
+  fail:
+    msg: "kube-networking namespace creation failed"
+  when: not kube_networking_namespace.rc == 0
 
 - name: Deploy canal configuration
   command: >

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yml
@@ -19,11 +19,19 @@
     timeout: 600
   with_items: "{{ api_servers }}"
 
+- name: check kube-networking namespace state
+  command: >  
+    kubectl --kubeconfig={{ kubeconfig | expanduser }} get namespace kube-networking
+  ignore_errors: yes
+  changed_when: false
+  register: kube_networking_namespace
+
 - name: Ensure the kube-networking namespace exists
   command: >
     kubectl --kubeconfig={{ kubeconfig | expanduser }} create namespace kube-networking
   retries: 120
   delay: 1
+  when: not kube_networking_namespace.rc == 0
 
 - name: Deploy canal configuration
   command: >


### PR DESCRIPTION
On a second "up" run, `Ensure the kube-networking namespace exists`
failed with:
> "Error from server: namespaces \"kube-networking\" already exists", "stdout"

This checks to see if the namespace has already been created and skips
creation if it does.