### PR TITLE
Master nodes are taking up to 4.5 minutes to be listening

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -154,7 +154,7 @@ resource "aws_elb" "master_elb" {
     unhealthy_threshold = 10
     timeout = 10
     target = "TCP:443"
-    interval = 20
+    interval = 45
   }
 
   tags {


### PR DESCRIPTION
Since the ELB health checks expire in 200 seconds, often the api server
is not yet listening. Extend the check interval to 45 seconds to allow a
450 second start time.