### PR TITLE
Use short health check intervals and a long grace period

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -152,9 +152,9 @@ resource "aws_elb" "master_elb" {
   health_check {
     healthy_threshold = 2
     unhealthy_threshold = 10
-    timeout = 10
+    timeout = 2
     target = "TCP:443"
-    interval = 45
+    interval = 5
   }
 
   tags {
@@ -238,7 +238,7 @@ resource "aws_autoscaling_group" "master_nodes" {
   launch_configuration      = "${aws_launch_configuration.master_launch_config.name}"
   wait_for_capacity_timeout = "0"
   force_delete              = true
-  health_check_grace_period = "30"
+  health_check_grace_period = "450"
   max_size                  = "{{kraken_config.master.nodepool.count}}"
   min_size                  = "{{kraken_config.master.nodepool.count}}"
   desired_capacity          = "{{kraken_config.master.nodepool.count}}"


### PR DESCRIPTION
The aws auto scale group can be configured with a health check grace
period. This allows us to have shorter duration health checks to respond
to needs faster, while still giving the instance time to start all its
services.