### PR TITLE
Delete cluster when not fully up

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml
@@ -16,7 +16,7 @@
 
 - name: Check for terraform success
   fail: "msg='Run cluster {{kraken_action}} failed!'"
-  when: kraken_action == 'up' and up_result|failed
+  when: (kraken_action == 'up') and (up_result|failed)
   changed_when: false
 
 - name: Get kraken endpoint

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml
@@ -34,12 +34,11 @@
   shell: > 
     terraform output -no-color kraken_private_zone_id chdir={{ config_base | expanduser }}/{{kraken_config.cluster}}
   register: zone_result 
-  when: kraken_action == 'up'
+  changed_when: false
 
 - name: Write zone id to file (THANKS, TERRAFORM)
   copy: >
     content={{ zone_result.stdout }} dest={{ config_base | expanduser }}/{{kraken_config.cluster}}/route53_zone
-  when: kraken_action == 'up'
 
 - name: Kill off the hosted zone using cli53 (THANKS, TERRAFORM)
   command: >

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml
@@ -14,8 +14,10 @@
   delay: 15
   ignore_errors: yes
 
-- fail: "msg='Run cluster {{kraken_action}} failed!'"
-  when: kraken_action == 'up' and up_result.rc != 0
+- name: Check for terraform success
+  fail: "msg='Run cluster {{kraken_action}} failed!'"
+  when: kraken_action == 'up' and up_result|failed
+  changed_when: false
 
 - name: Get kraken endpoint
   shell: > 

--- a/ansible/roles/kraken.services/tasks/main.yml
+++ b/ansible/roles/kraken.services/tasks/main.yml
@@ -26,4 +26,5 @@
 
 - include: kill-services.yaml
 - include: run-services.yaml
+  static: no
   when: kraken_action == 'up'


### PR DESCRIPTION
If `up` fails for whatever reason, `down` should still delete the cluster.