### PR TITLE
Add is_empty test

### DIFF
--- a/ansible/roles/kraken.config/filter_plugins/is_empty.py
+++ b/ansible/roles/kraken.config/filter_plugins/is_empty.py
@@ -1,0 +1,24 @@
+# from plugins/filter/json_query.py
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible.parsing.yaml.objects import AnsibleUnicode
+from ansible.utils.listify import listify_lookup_plugin_terms
+from jinja2.runtime import StrictUndefined
+
+def is_empty(data):
+    if isinstance(data, dict):
+        return data == {}
+    if isinstance(data, AnsibleUnicode):
+        return data.strip() == ""
+    if isinstance(data, StrictUndefined):
+        return True
+    return False
+
+class FilterModule(object):
+    ''' Query filter '''
+    def filters(self):
+        return {
+            'is_empty': is_empty
+        }
+

--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -27,7 +27,7 @@
 - name: Trigger a fatal error
   fail: 
     msg: "Make sure that the 'cluster' is defined in {{config_file}}"
-  when: (kraken_config.cluster is not defined) or (kraken_config.cluster is none) or (kraken_config.cluster|trim == '')
+  when: kraken_config.cluster | is_empty
 
 - name: Set the kubernetes cloud provider to {{ kraken_config.provider }}
   set_fact:
@@ -100,18 +100,12 @@
 - name: Set the provider type
   set_fact:
     kraken_config: "{{ kraken_config | combine({'providerConfig': {'type': 'cloudinit'}}, recursive=True) }}"
-  when: (kraken_config.providerConfig.type is undefined) or (kraken_config.providerConfig.type is none) or (kraken_config.providerConfig.type|trim == '')
+  when: kraken_config.providerConfig.type | is_empty
 
 - name: Generate random prefix if required
   set_fact:
     kraken_config: "{{ kraken_config | combine({'resourcePrefix': lookup('password', config_base + '/' + kraken_config.cluster + '/prefix' + ' chars=ascii_letters length=7')}, recursive=True) }}"
-  when: 
-    "(kraken_config.resourcePrefix is undefined) or 
-     (kraken_config.resourcePrefix is none) or 
-     (kraken_config.resourcePrefix|trim == '')"
+  when: kraken_config.resourcePrefix | is_empty
 
 - include: set-oidc-info.yaml
   when: "kraken_config.kubeAuth.authn.oidc is defined"
-
-  #- name: Display config
-  #  debug: var=kraken_config


### PR DESCRIPTION
This test eliminates long cumbersome definition tests like

```
(kraken_config.providerConfig.type is undefined) or (kraken_config.providerConfig.type is none) or (kraken_config.providerConfig.type|trim == '')
```
with

```
kraken_config.providerConfig.type | is_empty
```