### PR TITLE
Test success before testing json output

### DIFF
--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -55,7 +55,7 @@
 - name: Wait for tiller to be ready
   command: "kubectl --kubeconfig={{ kubeconfig | expanduser }} --namespace=kube-system get deploy tiller-deploy -o json"
   register: output
-  until: ((output.stdout | from_json).status.availableReplicas | default(0)) > 0
+  until: (output | succeeded) and ((output.stdout | from_json).status.availableReplicas | default(0)) > 0
   retries: 600
   delay: 1
   changed_when: false


### PR DESCRIPTION
Test to ensure kubectl returned 0 before testing its output in case it
failed and did not produce json. This will prevent an early failure in
the until loop if kubectl errored for some reason.

Fixes #252