### PR TITLE
Add an "until" to test the retry against

### DIFF
--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -29,7 +29,9 @@
 - name: Ensure the kube-networking namespace exists
   command: >
     kubectl --kubeconfig={{ kubeconfig | expanduser }} create namespace kube-networking
+  register: result
   retries: 120
+  until: result|succeeded
   delay: 1
   when: not kube_networking_namespace.rc == 0
   ignore_errors: yes


### PR DESCRIPTION
I mistakenly thought that a retries clause without an until would retry
until the command succeeded. The ansible documentation is insufficient
on this point.