### PR TITLE
I submit for your approval setting verbosity for ansible 

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -9,6 +9,8 @@ my_dir=$(dirname "${BASH_SOURCE}")
 # set KRAKEN_ROOT to absolute path for use in other scripts
 readonly KRAKEN_ROOT=$(cd "${my_dir}/.."; pwd)
 KRAKEN_VERBOSE=${KRAKEN_VERBOSE:-false}
+K2_VERBOSE=''
+KRAKEN_TF_LOG=k2_tf_debug.log
 
 # set RANDFILE to prevent creation of ${HOME}/.rnd by openssl
 export RANDFILE=$(mktemp)
@@ -96,6 +98,10 @@ case $key in
   KRAKEN_TAGS="$2"
   shift
   ;;
+  -v|--verbose)
+  K2_VERBOSE="$2"
+  shift
+  ;;
   -h|--help)
   KRAKEN_HELP=true
   ;;
@@ -131,8 +137,13 @@ fi
 
 KRAKEN_EXTRA_VARS="config_path=${KRAKEN_CONFIG} config_base=${KRAKEN_BASE} "
 
-if [ -z ${BUILD_TAG+x} ]; then
-    VERBOSE=""
-else
-    VERBOSE=-vvv
+if [ ! -z ${BUILD_TAG+x} ]; then
+    K2_VERBOSE='-vvv'
 fi
+
+if [ ! -z ${K2_VERBOSE+x} ]; then
+   TF_LOG_PATH="${KRAKEN_ROOT}/${KRAKEN_TF_LOG}"
+   TF_LOG=DEBUG
+fi
+
+

--- a/down.sh
+++ b/down.sh
@@ -11,4 +11,4 @@ set -o pipefail
 my_dir=$(dirname "${BASH_SOURCE}")
 source "${my_dir}/bin/utils.sh"
 
-ansible-playbook ${VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}"
+ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}"

--- a/up.sh
+++ b/up.sh
@@ -14,6 +14,6 @@ source "${my_dir}/bin/utils.sh"
 # setup a sigint trap
 trap control_c SIGINT
 
-DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" || show_post_cluster_error
+DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" || show_post_cluster_error
 
 show_post_cluster

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,6 @@ source "${my_dir}/bin/utils.sh"
 # setup a sigint trap
 trap control_c SIGINT
 
-DISPLAY_SKIPPED_HOSTS=0 ansible-playbook -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" || show_post_cluster_error
+DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" || show_post_cluster_error
 
 show_post_cluster


### PR DESCRIPTION
via a -v, let me know what you think and we can address it in a different manner if you wish.

example:

```
 ./up.sh -o ~/.kraken/ -c ~/.kraken/ae-cynosure_config.yaml -t 'ssh' -v '-vvv'
```