### PR TITLE
Reduce terraform retries

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.tf.jinja2
@@ -4,7 +4,7 @@ provider "aws" {
   shared_credentials_file = "{{kraken_config.providerConfig.authentication.credentialsFile}}"
   profile     = "{{kraken_config.providerConfig.authentication.credentialsProfile}}"
   region      = "{{kraken_config.providerConfig.region}}"
-  max_retries = "100"
+  max_retries = "8"
 }
 
 module "vpc" {


### PR DESCRIPTION
100 retries with an exponential backoff leads to wait times between
attemps in the millenia. Reduce to 8 which is only in the realm of
minutes.