### PR TITLE
Make readiness a cluster level property instead of a top level

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -385,10 +385,10 @@ deployment:
           keyPair: *defaultKeyPair
       fabricConfig: *defaultCanalFabric
       helmConfig: *defaultHelm
-  readiness:
-    type: exact
-    value: 0
-    wait: 600
+      readiness:
+        type: exact
+        value: 0
+        wait: 600
 
 # These are the old definitions included for backwards compatibility while we
 # convert each Ansible task to reference the new definitions and organization.
@@ -501,3 +501,7 @@ deployment:
         chart: heapster
         version: 0.1.0
         namespace: kube-system
+  readiness:
+    type: exact
+    value: 0
+    wait: 600


### PR DESCRIPTION
one. In a future with federated clusters, this value will not
be the same for all clusters.