### PR TITLE
Use valid version strings that can be version matched

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: v1alpha
+version: 0.0.1-alpha
 # These are the new definitions which are used throughout the configuration.
 definitions:
   helmConfigs:


### PR DESCRIPTION
There are standards for version strings that will allow version
comparison and matching. Let's use that so we can then determine version
progression and implement tests for same.