### PR TITLE
uses kubeConfig from new config file for k8s minor version fact in aws

### DIFF
--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -121,13 +121,17 @@
     kraken_config: "{{ kraken_config | combine({'providerConfig': {'type': 'cloudinit' }}, recursive=True) }}"
   when: kraken_config.providerConfig.type | is_empty
 
-- name: Set kubernetes minor version for master nodes
+- name: Set kubernetes minor version for master nodes in aws
   set_fact:
-    kubernetes_minor_version: "{{ masterVersion[0:(masterVersion.find('.', 3)) ] }}"
+    kubernetes_minor_version: "{{ masterVersion[0:(masterVersion.find('.', 3 ))]}}"
+  with_subelements:
+     - "{{ kraken_config.clusters }}"
+     - nodePools
+  loop_control:
+    loop_var: cluster_node_tuple
   vars:
-    # json_query returns a list of items, which in this case is one element long.
-    masterVersion: "{{ (kraken_config | json_query('nodepool[?name==`masterNodes`].kubeConfig.version'))[0] }}"
-  when: kraken_config.provider == 'aws'
+    masterVersion: "{{ cluster_node_tuple.1.kubeConfig.version }}"
+  when: (cluster_node_tuple.1.apiServerConfig is defined)
 
 - name: Generate random prefix if required
   set_fact:


### PR DESCRIPTION
from issue #271 

Will have to update for gke k8s minor version fact as well. Unclear if this should wait until k2recon merges back with master, or just pull it from a file and make changes right now. @coffeepac ?