### PR TITLE
K2-341 fix deprecated argument

### DIFF
--- a/ansible/roles/kraken.master/kraken.master.docker/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.master/kraken.master.docker/templates/units.kubelet.part.jinja2
@@ -40,7 +40,7 @@
       --api_servers=http://127.0.0.1:8080 \
       --register-schedulable=false \
       --allow-privileged=true \
-      --config=/etc/kubernetes/manifests \
+      --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
       --node-labels=nodepool={{kraken_config.master.nodepool.name}} \
       --hostname-override=${DEFAULT_IPV4} \

--- a/ansible/roles/kraken.node/kraken.node.docker/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.node/kraken.node.docker/templates/units.kubelet.part.jinja2
@@ -44,7 +44,7 @@
       --register-node=true \
       --node-labels=nodepool={{item.nodepool.name}} \
       --allow-privileged=true \
-      --config=/etc/kubernetes/manifests \
+      --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
       --cluster-dns={{kraken_config.serviceDNS}} \
       --cluster-domain={{kraken_config.clusterDomain}} \


### PR DESCRIPTION

`--config` has been deprecated since kube 1.4.   replace with `--pod-manifest-path`

https://github.com/samsung-cnct/k2/issues/341