### PR TITLE
k2-283 Separate DNS Service from Helm

### DIFF
--- a/Documentation/kraken-configs/clusterservices.md
+++ b/Documentation/kraken-configs/clusterservices.md
@@ -37,13 +37,10 @@ clusterServices:
         url: http://atlas.cnct.io
     services:
       -
-        name: kubedns
+        name: heapster
         repo: atlas
-        chart: kubedns
+        chart: heapster
         version: 0.1.0
         namespace: kube-system
-        values:
-          cluster_ip: 10.32.0.2
-          dns_domain: krakenCluster.local
-
+        
 ```

--- a/Documentation/kraken-configs/deployment.md
+++ b/Documentation/kraken-configs/deployment.md
@@ -11,8 +11,8 @@ The snippet configuration for deployments depends on the provider.
 | cluster | __Required__ | String | Name to use for the cluster created by this deployment |
 | resourcePrefix | Optional | String | Tagging and naming prefix for providers that need it. Defaults to a random string of 5 letters |
 | serviceCidr | __Required__ | String | Cluster service ip range CIDR |
-| serviceDNS | __Required__ | String | Cluster (kubedns) service IP |
-| clusterDomain | __Required__ | String | Domain name for cluster (internal resolution) |
+| serviceDNS | __Required__ | String | Cluster (kubedns) service IP <br>Also must set in `clusterServices.kubedns.cluster_ip`  |
+| clusterDomain | __Required__ | String | Domain name for cluster (internal resolution) <br>Also must set in `clusterServices.kubedns.dns_domain` |
 | coreos | Optional | Object array | named CoreOS options array|
 | keypair | Optional | Object Array | Array of key pairs to use in this deployment (in node pools and so on) |
 | kubeConfig | __Required__ | Object Array | Array of [Kubernetes configurations](kubernetes.md) |
@@ -102,6 +102,11 @@ The snippet configuration for deployments depends on the provider.
       # node config
     clusterServices:
       # cluster services config
+      kubedns:
+        name: kubedns
+        namespace: kube-system
+        cluster_ip: 10.32.0.2
+        dns_domain: cluster.local
     etcd:
       # etcd config
 ```

--- a/Documentation/security/example/config.yaml
+++ b/Documentation/security/example/config.yaml
@@ -342,16 +342,12 @@ deployment:
       -
         name: atlas
         url: http://atlas.cnct.io
-    services:
-      -
+    kubedns:
         name: kubedns
-        repo: atlas
-        chart: kubedns
-        version: 0.1.0
         namespace: kube-system
-        values:
-          cluster_ip: 10.32.0.2
-          dns_domain: cluster.local
+        cluster_ip: 10.32.0.2
+        dns_domain: cluster.local
+    services:
       -
         name: heapster
         repo: atlas

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -12,14 +12,6 @@ definitions:
         - name: stable
           url: https://kubernetes-charts.storage.googleapis.com
       charts:
-        - name: kubedns
-          repo: atlas
-          chart: kubedns
-          version: 0.1.0
-          namespace: kube-system
-          values:
-            cluster_ip: 10.32.0.2
-            dns_domain: cluster.local
         - name: heapster
           repo: atlas
           chart: heapster
@@ -480,16 +472,12 @@ deployment:
       -
         name: atlas
         url: http://atlas.cnct.io
-    services:
-      -
+    kubedns:
         name: kubedns
-        repo: atlas
-        chart: kubedns
-        version: 0.1.0
         namespace: kube-system
-        values:
-          cluster_ip: 10.32.0.2
-          dns_domain: cluster.local
+        cluster_ip: 10.32.0.2
+        dns_domain: cluster.local
+    services:
       -
         name: heapster
         repo: atlas

--- a/ansible/roles/kraken.services/defaults/main.yaml
+++ b/ansible/roles/kraken.services/defaults/main.yaml
@@ -4,3 +4,60 @@ helm_home: "{{ config_base | expanduser }}/{{ kraken_config.cluster }}/.helm"
 tiller: tiller-deploy
 tiller_image:
 api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
+#
+# Last Resort Vars used for kubedns
+# 4/13/2017 - mln
+kubedns:
+  k8sapp: "kube-dns"
+  service_name: "KubeDNS"
+  namespace: "kube-system"
+  dns_domain: "cluster.local"
+  cluster_ip: 10.100.0.10
+  replicas: 1
+  version: v17
+  color: FFFF66
+  kubedns_image: "gcr.io/google_containers/kubedns-amd64:1.8"
+  kubedns_image_v16: "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1"
+  kubedns_image_v15: "gcr.io/google_containers/kubedns-amd64:1.9"
+  kubedns_image_v14: "gcr.io/google_containers/kubedns-amd64:1.8"
+  kubedns_log_level: 0
+  kubedns_max_surge: 10%
+  kubedns_max_unavail: 0
+  kubedns_cpu_lim: 100m
+  kubedns_mem_lim: 170Mi
+  kubedns_cpu_req: 100m
+  kubedns_mem_req: 70Mi
+  healthz_image: "gcr.io/google_containers/exechealthz-amd64:1.2"
+  healthz_image_v15: "gcr.io/google_containers/exechealthz-amd64:1.2"
+  healthz_image_v14: "gcr.io/google_containers/exechealthz-amd64:1.2"
+  healthz_cpu_lim: 10m
+  healthz_mem_lim: 50Mi
+  healthz_cpu_req: 10m
+  healthz_mem_req: 50Mi
+  healthz_delay: 60
+  healthz_timeout: 5
+  healthz_success_thresh: 1
+  healthz_failure_thresh: 5
+  readiness_delay: 3
+  readiness_timeout: 5
+  dnsmasq_image: "gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1"
+  dnsmasq_image_v16: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1"
+  dnsmasq_image_v15: "gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1"
+  dnsmasq_image_v14: "gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1"
+  dnsmasq_delay: 60
+  dnsmasq_timeout: 5
+  dnsmasq_succ_thresh: 1
+  dnsmasq_fail_thresh: 5 
+  dnsmasq_cpu_req: 150m
+  dnsmasq_mem_req: 10Mi
+  dnsmasq_metrics_image_v16: "gcr.io/google_containers/k2s-dns-sidecare-amd64:1.14.1"
+  dnsmasq_metrics_image_v15: "gcr.io/google_containers/dnsmasq-metrics-amd64:1.0.1"
+  dnsmasq_metrics_delay: 60
+  dnsmasq_metrics_timeout: 5
+  dnsmasq_metrics_succ_thresh: 1
+  dnsmasq_metrics_fail_thresh: 5 
+  dnsmasq_log_level: 2
+  dnsmasq_metrics_mem_req: 20Mi
+  dnsmasq_metrics_cpu_req: 10m
+ 
+

--- a/ansible/roles/kraken.services/tasks/kill-dns.yaml
+++ b/ansible/roles/kraken.services/tasks/kill-dns.yaml
@@ -1,0 +1,6 @@
+---
+- name: Clean up DNS
+  command: >
+    kubectl --kubeconfig={{ kubeconfig }} delete -f {{ config_base | expanduser }}/{{ kraken_config.cluster }}/services/dns-deployment.yaml --namespace={{ dns_config.namespace }}
+  when: kraken_action == 'down'
+  ignore_errors: yes

--- a/ansible/roles/kraken.services/tasks/main.yaml
+++ b/ansible/roles/kraken.services/tasks/main.yaml
@@ -17,6 +17,20 @@
 - include: generate-oidc-cert.yaml
   when: (kraken_config.kubeAuth.authn.oidc is defined) and (kraken_action == 'up')
 
+- name: Merge User DNS Config with Default DNS Config
+  set_fact:
+    dns_config: "{{ kubedns | combine(kraken_config.clusterServices.kubedns) | expand_config }}"
+
+- debug:
+    var: dns_config
+
+- include: kill-dns.yaml
+  static: no
+  when: kraken_action == 'down'
+- include: run-dns.yaml
+  static: no
+  when: kraken_action == 'up'
+
 - name: See if tiller rc if present
   shell: >
     kubectl --kubeconfig={{ kubeconfig }} get deployment {{ tiller }} --namespace=kube-system

--- a/ansible/roles/kraken.services/tasks/run-dns.yaml
+++ b/ansible/roles/kraken.services/tasks/run-dns.yaml
@@ -1,0 +1,29 @@
+---
+- name: Make sure generated folder for services is there
+  file: >
+    path="{{ config_base | expanduser }}/{{ kraken_config.cluster }}/services"
+    state=directory
+
+- debug: 
+    var: kubernetes_minor_version
+
+- name: Create the DNS Service Deployment
+  template: src="{{ item }}"
+    dest="{{ config_base | expanduser }}/{{ kraken_config.cluster }}/services/dns-deployment.yaml"
+  with_first_found:
+    - files:
+      - "{{ kubernetes_minor_version }}/dns.yaml.jinja2"
+      - dns.yaml.jinja2
+
+- name: Wait for api server to become available in case it is not already
+  wait_for:
+    host: "{{ item | regex_replace('https://','') }}"
+    port: 443
+    timeout: 600
+  with_items: "{{ api_servers }}"
+
+- name: Install DNS
+  command: >
+      kubectl --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{ kraken_config.cluster }}/services/dns-deployment.yaml 
+  register: deployment_dns_result
+

--- a/ansible/roles/kraken.services/templates/dns.yaml.jinja2
+++ b/ansible/roles/kraken.services/templates/dns.yaml.jinja2
@@ -1,0 +1,144 @@
+# This installs the items needed for the cluster
+# internal DNS
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+  labels:
+    k8s-app: "{{dns_config.k8sapp}}-{{dns_config.version}}"
+    kubernetes.io/cluster-service: "true"
+    version: {{dns_config.version}}
+spec:
+  replicas: {{dns_config.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{dns_config.kubedns_max_surge}}
+      maxUnavailable: {{dns_config.kubedns_max_unavail}}
+  selector:
+    matchLabels:
+      k8s-app: {{dns_config.k8sapp}}
+      version: {{dns_config.version}}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{dns_config.k8sapp}}
+        version: {{dns_config.version}}
+        cagby.io/color: {{dns_config.color}}
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+        - name: kubedns
+          image: {{dns_config.kubedns_image}}
+          resources:
+            # TODO: Set memory limits when we've profiled the container for large
+            # clusters, then set request = limit to keep this container in
+            # guaranteed class. Currently, this container falls into the
+            # "burstable" category so the kubelet doesn't backoff from restarting it.
+            limits:
+              cpu: {{dns_config.kubedns_cpu_lim}}
+              memory: {{dns_config.kubedns_mem_lim}}
+            requests:
+              cpu: {{dns_config.kubedns_cpu_req}}
+              memory: {{dns_config.kubedns_mem_req}}
+          livenessProbe:
+            httpGet:
+              path: /healthz-kubedns
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.healthz_delay}}
+            timeoutSeconds: {{dns_config.healthz_timeout}}
+            successThreshold: {{dns_config.healthz_success_thresh}}
+            failureThreshold: {{dns_config.healthz_failure_thresh}}
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8081
+              scheme: HTTP
+            # we poll on pod startup for the Kubernetes master service and
+            # only setup the /readiness HTTP server once that's available.
+            initialDelaySeconds: {{dns_config.readiness_delay}}
+            timeoutSeconds: {{dns_config.readiness_timeout}}
+          args:
+          - --domain={{dns_config.dns_domain}}
+          - --dns-port=10053
+          - --v={{dns_config.kubedns_log_level}}
+          # __pillar['federations_domain_map']__
+          ports:
+          - containerPort: 10053
+            name: dns-local
+            protocol: UDP
+          - containerPort: 10053
+            name: dns-tcp-local
+            protocol: TCP
+        - name: dnsmasq
+          image: {{dns_config.dnsmasq_image}}
+          livenessProbe:
+            httpGet:
+              path: /healthz-dnsmasq
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.dnsmasq_delay}}
+            timeoutSeconds: {{dns_config.dnsmasq_timeout}}
+            successThreshold: {{dns_config.dnsmasq_succ_thresh}}
+            failureThreshold: {{dns_config.dnsmasq_fail_thresh}}
+          args:
+          - --cache-size=1000
+          - --no-resolv
+          - --server=127.0.0.1#10053
+          #- --log-facility=-
+          ports:
+          - containerPort: 53
+            name: dns
+            protocol: UDP
+          - containerPort: 53
+            name: dns-tcp
+            protocol: TCP
+        - name: healthz
+          image: {{dns_config.healthz_image}}
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: {{dns_config.healthz_cpu_lim}}
+              memory: {{dns_config.healthz_mem_lim}}
+            requests:
+              cpu: {{dns_config.healthz_cpu_req}}
+              memory: {{dns_config.healthz_mem_req}}
+          args:
+            - --cmd=nslookup kubernetes.default.svc.{{dns_config.dns_domain}} 127.0.0.1 >/dev/null
+            - --url=/healthz-dnsmasq
+            - --cmd=nslookup kubernetes.default.svc.{{dns_config.dns_domain}} 127.0.0.1:10053 >/dev/null
+            - --url=/healthz-kubedns
+            - --port=8080
+            - --quiet
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+      dnsPolicy: Default  # Don't use cluster DNS.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: {{dns_config.k8sapp}}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: {{dns_config.service_name}}
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  selector:
+    k8s-app: {{dns_config.k8sapp}}
+  clusterIP: {{dns_config.cluster_ip}}
+

--- a/ansible/roles/kraken.services/templates/v1.4/dns.yaml.jinja2
+++ b/ansible/roles/kraken.services/templates/v1.4/dns.yaml.jinja2
@@ -1,0 +1,144 @@
+# This installs the items needed for the cluster
+# internal DNS
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+  labels:
+    k8s-app: "{{dns_config.k8sapp}}-{{dns_config.version}}"
+    kubernetes.io/cluster-service: "true"
+    version: {{dns_config.version}}
+spec:
+  replicas: {{dns_config.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{dns_config.kubedns_max_surge}}
+      maxUnavailable: {{dns_config.kubedns_max_unavail}}
+  selector:
+    matchLabels:
+      k8s-app: {{dns_config.k8sapp}}
+      version: {{dns_config.version}}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{dns_config.k8sapp}}
+        version: {{dns_config.version}}
+        cagby.io/color: {{dns_config.color}}
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+        - name: kubedns
+          image: {{dns_config.kubedns_image_v14}}
+          resources:
+            # TODO: Set memory limits when we've profiled the container for large
+            # clusters, then set request = limit to keep this container in
+            # guaranteed class. Currently, this container falls into the
+            # "burstable" category so the kubelet doesn't backoff from restarting it.
+            limits:
+              cpu: {{dns_config.kubedns_cpu_lim}}
+              memory: {{dns_config.kubedns_mem_lim}}
+            requests:
+              cpu: {{dns_config.kubedns_cpu_req}}
+              memory: {{dns_config.kubedns_mem_req}}
+          livenessProbe:
+            httpGet:
+              path: /healthz-kubedns
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.healthz_delay}}
+            timeoutSeconds: {{dns_config.healthz_timeout}}
+            successThreshold: {{dns_config.healthz_success_thresh}}
+            failureThreshold: {{dns_config.healthz_failure_thresh}}
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8081
+              scheme: HTTP
+            # we poll on pod startup for the Kubernetes master service and
+            # only setup the /readiness HTTP server once that's available.
+            initialDelaySeconds: {{dns_config.readiness_delay}}
+            timeoutSeconds: {{dns_config.readiness_timeout}}
+          args:
+          - --domain={{dns_config.dns_domain}}
+          - --dns-port=10053
+          - --v={{dns_config.kubedns_log_level}}
+          # __pillar['federations_domain_map']__
+          ports:
+          - containerPort: 10053
+            name: dns-local
+            protocol: UDP
+          - containerPort: 10053
+            name: dns-tcp-local
+            protocol: TCP
+        - name: dnsmasq
+          image: {{dns_config.dnsmasq_image_v14}}
+          livenessProbe:
+            httpGet:
+              path: /healthz-dnsmasq
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.dnsmasq_delay}}
+            timeoutSeconds: {{dns_config.dnsmasq_timeout}}
+            successThreshold: {{dns_config.dnsmasq_succ_thresh}}
+            failureThreshold: {{dns_config.dnsmasq_fail_thresh}}
+          args:
+          - --cache-size=1000
+          - --no-resolv
+          - --server=127.0.0.1#10053
+          #- --log-facility=-
+          ports:
+          - containerPort: 53
+            name: dns
+            protocol: UDP
+          - containerPort: 53
+            name: dns-tcp
+            protocol: TCP
+        - name: healthz
+          image: {{dns_config.healthz_image_v14}}
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: {{dns_config.healthz_cpu_lim}}
+              memory: {{dns_config.healthz_mem_lim}}
+            requests:
+              cpu: {{dns_config.healthz_cpu_req}}
+              memory: {{dns_config.healthz_mem_req}}
+          args:
+            - --cmd=nslookup kubernetes.default.svc.{{dns_config.dns_domain}} 127.0.0.1 >/dev/null
+            - --url=/healthz-dnsmasq
+            - --cmd=nslookup kubernetes.default.svc.{{dns_config.dns_domain}} 127.0.0.1:10053 >/dev/null
+            - --url=/healthz-kubedns
+            - --port=8080
+            - --quiet
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+      dnsPolicy: Default  # Don't use cluster DNS.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: {{dns_config.k8sapp}}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: {{dns_config.service_name}}
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  selector:
+    k8s-app: {{dns_config.k8sapp}}
+  clusterIP: {{dns_config.cluster_ip}}
+

--- a/ansible/roles/kraken.services/templates/v1.5/dns.yaml.jinja2
+++ b/ansible/roles/kraken.services/templates/v1.5/dns.yaml.jinja2
@@ -1,0 +1,176 @@
+# This installs the items needed for the cluster
+# internal DNS
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+  labels:
+    k8s-app: "{{dns_config.k8sapp}}-{{dns_config.version}}"
+    kubernetes.io/cluster-service: "true"
+    version: {{dns_config.version}}
+spec:
+  replicas: {{dns_config.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{dns_config.kubedns_max_surge}}
+      maxUnavailable: {{dns_config.kubedns_max_unavail}}
+  selector:
+    matchLabels:
+      k8s-app: {{dns_config.k8sapp}}
+      version: {{dns_config.version}}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{dns_config.k8sapp}}
+        version: {{dns_config.version}}
+        cagby.io/color: {{dns_config.color}}
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+        - name: kubedns
+          image: {{dns_config.kubedns_image_v15}}
+          resources:
+            # TODO: Set memory limits when we've profiled the container for large
+            # clusters, then set request = limit to keep this container in
+            # guaranteed class. Currently, this container falls into the
+            # "burstable" category so the kubelet doesn't backoff from restarting it.
+            limits:
+              cpu: {{dns_config.kubedns_cpu_lim}}
+              memory: {{dns_config.kubedns_mem_lim}}
+            requests:
+              cpu: {{dns_config.kubedns_cpu_req}}
+              memory: {{dns_config.kubedns_mem_req}}
+          livenessProbe:
+            httpGet:
+              path: /healthz-kubedns
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.healthz_delay}}
+            timeoutSeconds: {{dns_config.healthz_timeout}}
+            successThreshold: {{dns_config.healthz_success_thresh}}
+            failureThreshold: {{dns_config.healthz_failure_thresh}}
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8081
+              scheme: HTTP
+            # we poll on pod startup for the Kubernetes master service and
+            # only setup the /readiness HTTP server once that's available.
+            initialDelaySeconds: {{dns_config.readiness_delay}}
+            timeoutSeconds: {{dns_config.readiness_timeout}}
+          args:
+          - --domain={{dns_config.dns_domain}}
+          - --dns-port=10053
+          - --config-map={{dns_config.k8sapp}}
+          - --v={{dns_config.kubedns_log_level}}
+          # __pillar['federations_domain_map']__
+          env:
+          - name: PROMETHEUS_PORT
+            value: "10055"
+          ports:
+          - containerPort: 10053
+            name: dns-local
+            protocol: UDP
+          - containerPort: 10053
+            name: dns-tcp-local
+            protocol: TCP
+          - containerPort: 10055
+            name: metrics
+            protocol: TCP
+        - name: dnsmasq
+          image: {{dns_config.dnsmasq_image_v15}}
+          livenessProbe:
+            httpGet:
+              path: /healthz-dnsmasq
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.dnsmasq_delay}}
+            timeoutSeconds: {{dns_config.dnsmasq_timeout}}
+            successThreshold: {{dns_config.dnsmasq_succ_thresh}}
+            failureThreshold: {{dns_config.dnsmasq_fail_thresh}}
+          args:
+          - --cache-size=1000
+          - --no-resolv
+          - --server=127.0.0.1#10053
+          - --log-facility=-
+          ports:
+          - containerPort: 53
+            name: dns
+            protocol: UDP
+          - containerPort: 53
+            name: dns-tcp
+            protocol: TCP
+          resources:
+            requests:
+              cpu: {{dns_config.dnsmasq_cpu_req}}
+              memory: {{dns_config.dnsmasq_mem_req}}
+        - name: dnsmasq-metrics
+          image: {{dns_config.dnsmasq_metrics_image_v15}} 
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.dnsmasq_metrics_delay}}
+            timeoutSeconds: {{dns_config.dnsmasq_metrics_timeout}}
+            successThreshold: {{dns_config.dnsmasq_metrics_succ_thresh}}
+            failureThreshold: {{dns_config.dnsmasq_metrics_fail_thresh}}
+          args:
+          - --v={{dns_config.dnsmasq_log_level}}
+          - --logtostderr
+          ports:
+          - containerPort: 10054
+            name: metrics
+            protocol: TCP
+          resources:
+            requests:
+              memory: {{dns_config.dnsmasq_metrics_mem_req}}
+        - name: healthz
+          image: {{dns_config.healthz_image_v15}}
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: {{dns_config.healthz_cpu_lim}}
+              memory: {{dns_config.healthz_mem_lim}}
+            requests:
+              cpu: {{dns_config.healthz_cpu_req}}
+              memory: {{dns_config.healthz_mem_req}}
+          args:
+            - --cmd=nslookup kubernetes.default.svc.{{dns_config.dns_domain}} 127.0.0.1 >/dev/null
+            - --url=/healthz-dnsmasq
+            - --cmd=nslookup kubernetes.default.svc.{{dns_config.dns_domain}} 127.0.0.1:10053 >/dev/null
+            - --url=/healthz-kubedns
+            - --port=8080
+            - --quiet
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+      dnsPolicy: Default  # Don't use cluster DNS.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: {{dns_config.k8sapp}}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: {{dns_config.service_name}}
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  selector:
+    k8s-app: {{dns_config.k8sapp}}
+  clusterIP: {{dns_config.cluster_ip}}
+

--- a/ansible/roles/kraken.services/templates/v1.6/dns.yaml.jinja2
+++ b/ansible/roles/kraken.services/templates/v1.6/dns.yaml.jinja2
@@ -1,0 +1,196 @@
+# This installs the items needed for the cluster
+# internal DNS
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+  labels:
+    k8s-app: "{{dns_config.k8sapp}}-{{dns_config.version}}"
+    kubernetes.io/cluster-service: "true"
+    version: {{dns_config.version}}
+    #addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: {{dns_config.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{dns_config.kubedns_max_surge}}
+      maxUnavailable: {{dns_config.kubedns_max_unavail}}
+  selector:
+    matchLabels:
+      k8s-app: {{dns_config.k8sapp}}
+      version: {{dns_config.version}}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{dns_config.k8sapp}}
+        version: {{dns_config.version}}
+        cagby.io/color: {{dns_config.color}}
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exsits"
+      volumes:
+        - name: kube-dns-config
+          configMap:
+            name: {{dns_config.k8sapp}}
+            optional: true
+      containers:
+        - name: kubedns
+          image: {{dns_config.kubedns_image_v16}}
+          resources:
+            # TODO: Set memory limits when we've profiled the container for large
+            # clusters, then set request = limit to keep this container in
+            # guaranteed class. Currently, this container falls into the
+            # "burstable" category so the kubelet doesn't backoff from restarting it.
+            limits:
+              cpu: {{dns_config.kubedns_cpu_lim}}
+              memory: {{dns_config.kubedns_mem_lim}}
+            requests:
+              cpu: {{dns_config.kubedns_cpu_req}}
+              memory: {{dns_config.kubedns_mem_req}}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/kubedns
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.healthz_delay}}
+            timeoutSeconds: {{dns_config.healthz_timeout}}
+            successThreshold: {{dns_config.healthz_success_thresh}}
+            failureThreshold: {{dns_config.healthz_failure_thresh}}
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8081
+              scheme: HTTP
+            # we poll on pod startup for the Kubernetes master service and
+            # only setup the /readiness HTTP server once that's available.
+            initialDelaySeconds: {{dns_config.readiness_delay}}
+            timeoutSeconds: {{dns_config.readiness_timeout}}
+          args:
+          - --domain={{dns_config.dns_domain}}
+          - --dns-port=10053
+          - --config-map={{dns_config.k8sapp}}
+          - --v={{dns_config.kubedns_log_level}}
+          # __pillar['federations_domain_map']__
+          env:
+          - name: PROMETHEUS_PORT
+            value: "10055"
+          ports:
+          - containerPort: 10053
+            name: dns-local
+            protocol: UDP
+          - containerPort: 10053
+            name: dns-tcp-local
+            protocol: TCP
+          - containerPort: 10055
+            name: metrics
+            protocol: TCP
+          volumeMounts:
+          - name: kube-dns-config
+            mountPath: /kube-dns-config
+        - name: dnsmasq
+          image: {{dns_config.dnsmasq_image_v16}}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/dnsmasq
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.dnsmasq_delay}}
+            timeoutSeconds: {{dns_config.dnsmasq_timeout}}
+            successThreshold: {{dns_config.dnsmasq_succ_thresh}}
+            failureThreshold: {{dns_config.dnsmasq_fail_thresh}}
+          args:
+          - -v={{dns_config.dnsmasq_log_level}}
+          - -logtostderr
+          - --
+          - -k
+          - --cache-size=1000
+          - --log-facility=-
+          - --server=/{{dns_config.dns_domain}}/127.0.0.1#10053
+          - --server=/in-addr.arpa/127.0.0.1#10053
+          - --server=/ip6.arpa/127.0.0.1#10053
+          ports:
+          - containerPort: 53
+            name: dns
+            protocol: UDP
+          - containerPort: 53
+            name: dns-tcp
+            protocol: TCP
+          resources:
+            requests:
+              cpu: {{dns_config.dnsmasq_cpu_req}}
+              memory: {{dns_config.dnsmasq_mem_req}}
+          volumeMounts:
+          - name: kube-dns-config
+            mountPath: /etc/k8s/dns/dnsmasq-nanny
+        - name: sidecare 
+          image: {{dns_config.dnsmasq_metrics_image_v16}} 
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 10054
+              scheme: HTTP
+            initialDelaySeconds: {{dns_config.dnsmasq_metrics_delay}}
+            timeoutSeconds: {{dns_config.dnsmasq_metrics_timeout}}
+            successThreshold: {{dns_config.dnsmasq_metrics_succ_thresh}}
+            failureThreshold: {{dns_config.dnsmasq_metrics_fail_thresh}}
+          args:
+          - --v={{dns_config.dnsmasq_log_level}}
+          - --logtostderr
+          - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{dns_config.dns_domain}},5,A
+          - --probe=kubedns,127.0.0.1:53,kubernetes.default.svc.{{dns_config.dns_domain}},5,A
+          ports:
+          - containerPort: 10054
+            name: metrics
+            protocol: TCP
+          resources:
+            requests:
+              memory: {{dns_config.dnsmasq_metrics_mem_req}}
+              cpu: {{dns_config.dnsmasq_metrics_cpu_req}}
+      dnsPolicy: Default  # Don't use cluster DNS.
+      serviceAccountName: {{dns_config.k8sapp}} 
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+  labels:
+    #addonmanager.kubernetes.io/mode: EnsureExists
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{dns_config.k8sapp}}
+  labels:
+    kubernetes.io/cluster-service: "true"
+    #addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: {{dns_config.k8sapp}}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: {{dns_config.service_name}}
+    #addonmanager.kubernetes.io/mode: Reconcile
+  name: {{dns_config.k8sapp}}
+  namespace: {{ dns_config.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  selector:
+    k8s-app: {{dns_config.k8sapp}}
+  clusterIP: {{dns_config.cluster_ip}}
+


### PR DESCRIPTION
Separate DNS from Helm Services Deployment.
Need separate template for each kubernetes version,  default template pattered after kubernetes v1.4 template for now.
All infrequently changed variables are defaulted in defaults/main.yaml.
Any of those variables can be overridden by setting in the main config.yaml, but most should never be touched. 

https://github.com/samsung-cnct/k2/issues/283
