### PR TITLE
Kubernetes minor versions fact

### DIFF
--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -47,7 +47,7 @@
   with_subelements:
     - "{{ kraken_config.clusters }}"
     - nodePools
-  when: (item.1.apiServerConfig is defined)
+  when: (item.1.apiServerConfig is defined) or (item.0.providerConfig.provider == 'gke')
   vars:
     masterVersion: "{{ item.1.kubeConfig.version }}"
 

--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -43,5 +43,6 @@
     - nodePools
   loop_control:
     loop_var: cluster_node_tuple
+    
 - include: set-oidc-info.yaml
   when: "kraken_config.kubeAuth.authn.oidc is defined"

--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -37,7 +37,7 @@
          or (i.1.apiServerConfig is defined and i.1.kubeConfig is undefined)
          or (i.1.etcdConfig is undefined and i.1.kubeConfig is undefined)
 
-- name: Set kubernetes minor versions for each aws cluster
+- name: Set kubernetes minor versions for each aws or gke cluster
   set_fact:
     kubernetes_minor_versions: "{{ kubernetes_minor_versions| default({}) |combine
       (

--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -37,12 +37,26 @@
          or (i.1.apiServerConfig is defined and i.1.kubeConfig is undefined)
          or (i.1.etcdConfig is undefined and i.1.kubeConfig is undefined)
 
+- name: Set kubernetes minor versions for each aws cluster
+  set_fact:
+    kubernetes_minor_versions: "{{ kubernetes_minor_versions| default({}) |combine
+      (
+        { item.0.name: masterVersion[0:(masterVersion.find('.', 3 ))] }
+      )
+    }}"
+  with_subelements:
+    - "{{ kraken_config.clusters }}"
+    - nodePools
+  when: (item.1.apiServerConfig is defined)
+  vars:
+    masterVersion: "{{ item.1.kubeConfig.version }}"
+
 - include: setup.yaml
   with_subelements:
     - "{{ kraken_config.clusters }}"
     - nodePools
   loop_control:
     loop_var: cluster_node_tuple
-    
+
 - include: set-oidc-info.yaml
   when: "kraken_config.kubeAuth.authn.oidc is defined"

--- a/ansible/roles/kraken.config/tasks/setup.yaml
+++ b/ansible/roles/kraken.config/tasks/setup.yaml
@@ -82,13 +82,6 @@
     kraken_config: "{{ kraken_config | combine({'providerConfig': {'type': 'cloudinit' }}, recursive=True) }}"
   when: cluster.providerConfig.type | is_empty
 
-- name: Set kubernetes minor version for master nodes
-  set_fact:
-    kubernetes_minor_version: "{{ masterVersion[0:(masterVersion.find('.', 3))] }}"
-  vars:
-    masterVersion: "{{ node.kubeConfig.version }}"
-  when: node.apiServerConfig is defined
-
 - name: Generate random prefix if required
   set_fact:
     kraken_config: "{{ kraken_config | combine({'resourcePrefix': lookup('password', config_base + '/' + kraken_config.cluster + '/prefix' + ' chars=ascii_letters length=7')}, recursive=True) }}"


### PR DESCRIPTION
For AWS this will gather all kubernetes minor versions from all clusters specified in the config file and assign them to a top-level key called kubernetes_minor_version.
You can now look up each cluster's minor version by cluster name as follows:
kubernetes_minor_versions.<clusterName> and it should tell you the minor version.
This partially fulfills #345.
As per #337 the GKE work is still left to do.
