### PR TITLE
Allow the use of Ubuntu cloud images with aws

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: https://github.com/willthames/ansible-lint.git
-    sha: v3.4.11
+    sha: v3.4.12
     hooks:
     -   id: ansible-lint
         files: \.(yaml|yml)$

--- a/Documentation/kraken-configs/os.md
+++ b/Documentation/kraken-configs/os.md
@@ -1,12 +1,14 @@
 # OS Configuration
 
 ## Options
-| Key Name | Required     | Type    | Description  |
-| -------- | ------------ | ------  | ------------ |
-| type     | __Required__ | String  | Operating System |
-| version  | __Required__ |         |              |
-| channel  |              |         |              |
-| rebootStrategy |        |         |              |     
+| Key Name   | Required     | Type    | Description  |
+| --------   | ------------ | ------  | ------------ |
+| type       | __Required__ | String  | Operating System |
+| distro     | __Required__ | String  | Operating System Distro |
+| version    | __Required__ |         |              |
+| subversion |              |         |              |
+| channel    |              |         |              |
+| rebootStrategy |        |         |              |
 
 
 ```yaml
@@ -18,4 +20,11 @@ osConfigs:
     version: current
     channel: stable
     rebootStrategy: "off"
+  - &customUbuntu
+    name: customUbuntu
+    kind: os
+    type: ubuntu
+    distro: ubuntu
+    version: 16.04
+    subversion: latest
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You will need the following installed on your machine:
 - Terraform and providers
  - Terraform 0.7.x
  - Terraform execute provider 0.0.3 (https://github.com/samsung-cnct/terraform-provider-execute/releases)  
- - Terraform coreosbox provider 0.0.2 (https://github.com/samsung-cnct/terraform-provider-coreosbox/releases)
+ - Terraform distroimage provider 0.0.1 (https://github.com/samsung-cnct/terraform-provider-distroimage/releases)
 - kubectl 1.3.x
 - helm alpha.5 or later
 

--- a/ansible/roles/kraken.assembler/templates/node.yaml.jinja2
+++ b/ansible/roles/kraken.assembler/templates/node.yaml.jinja2
@@ -1,6 +1,8 @@
 #cloud-config
 
 ---
+{{ cloud_config[cluster.name][item.0.name] | to_nice_yaml(indent=2) }}
+
 write_files:
 {% for filedata in item.1.files %}
 {% if item.0.name + '.write_files.' in filedata.path %}

--- a/ansible/roles/kraken.cluster_common/tasks/cluster-start.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/cluster-start.yaml
@@ -14,7 +14,7 @@
     - "{{ cluster.nodePools }}"
   loop_control:
     loop_var: nodepool
-  when: nodepool.osConfig.distro == 'ubuntu'
+  when: nodepool.osConfig.type== 'ubuntu'
 
 - include: network_environment.yaml
 - include: certificate_authority.yaml

--- a/ansible/roles/kraken.cluster_common/tasks/cluster-start.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/cluster-start.yaml
@@ -8,23 +8,14 @@
     path: "{{ config_base | expanduser }}/{{ cluster.name }}"
     state: directory
 
-- name: rkt-install.yaml
-  debug:
-    var: nodepool
+- name: include rkt-install
+  include: rkt-install.yaml
   with_items:
     - "{{ cluster.nodePools }}"
   loop_control:
     loop_var: nodepool
   when: nodepool.osConfig.distro == 'ubuntu'
 
-- include: rkt-install.yaml
-  with_items:
-    - "{{ cluster.nodePools }}"
-  loop_control:
-    loop_var: nodepool
-  when: nodepool.osConfig.distro == 'ubuntu'
-
-- fail:
 - include: network_environment.yaml
 - include: certificate_authority.yaml
 - include: os_update.yaml

--- a/ansible/roles/kraken.cluster_common/tasks/cluster-start.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/cluster-start.yaml
@@ -8,6 +8,23 @@
     path: "{{ config_base | expanduser }}/{{ cluster.name }}"
     state: directory
 
+- name: rkt-install.yaml
+  debug:
+    var: nodepool
+  with_items:
+    - "{{ cluster.nodePools }}"
+  loop_control:
+    loop_var: nodepool
+  when: nodepool.osConfig.distro == 'ubuntu'
+
+- include: rkt-install.yaml
+  with_items:
+    - "{{ cluster.nodePools }}"
+  loop_control:
+    loop_var: nodepool
+  when: nodepool.osConfig.distro == 'ubuntu'
+
+- fail:
 - include: network_environment.yaml
 - include: certificate_authority.yaml
 - include: os_update.yaml

--- a/ansible/roles/kraken.cluster_common/tasks/rkt-install.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/rkt-install.yaml
@@ -1,0 +1,5 @@
+---
+- name: Generate .units.bootcmd-rkt.part files for {{ nodepool }}
+  template:
+    src: bootcmd-rkt.part.jinja2
+    dest: "{{ config_base | expanduser }}/{{ cluster.name }}/{{nodepool.name}}.bootcmd-rkt.part"

--- a/ansible/roles/kraken.cluster_common/tasks/rkt-install.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/rkt-install.yaml
@@ -1,5 +1,17 @@
 ---
-- name: Generate .units.bootcmd-rkt.part files for {{ nodepool }}
-  template:
-    src: bootcmd-rkt.part.jinja2
-    dest: "{{ config_base | expanduser }}/{{ cluster.name }}/{{nodepool.name}}.bootcmd-rkt.part"
+- name: Add cluster and nodepool to cloud_config
+  set_fact:
+    cloud_config: "{{ cloud_config | default({}) | combine(cluster_cloud_config_string | from_yaml, recursive=true) }}"
+  vars:
+    cluster_cloud_config_string: |
+      {{ cluster.name }}:
+        {{ nodepool.name }}: {}
+
+- name: Add bootcmd to install rkt for {{ nodepool.name }}
+  set_fact:
+    cloud_config: "{{ cloud_config | default({}) | combine(new_cloud_config, recursive=true) }}"
+  vars:
+    command:
+      - "wget -qO- https://github.com/rkt/rkt/releases/download/v1.25.0/rkt_1.25.0-1_amd64.deb | bsdtar xzOf - | bsdtar -C / -xzf -"
+    bootcmds: "{{ cloud_config[cluster.name][nodepool.name].bootcmd | default([]) }}"
+    new_cloud_config: '{{ { cluster.name: { nodepool.name: { "bootcmd": bootcmds + command }}} }}'

--- a/ansible/roles/kraken.cluster_common/templates/bootcmd-rkt.part.jinja2
+++ b/ansible/roles/kraken.cluster_common/templates/bootcmd-rkt.part.jinja2
@@ -1,0 +1,2 @@
+# TODO: Move the rkt version to config
+  - wget -qO- https://github.com/rkt/rkt/releases/download/v1.25.0/rkt_1.25.0-1_amd64.deb | bsdtar xzOf - | bsdtar -C / -xzf -

--- a/ansible/roles/kraken.cluster_common/templates/os.update.part.jinja2
+++ b/ansible/roles/kraken.cluster_common/templates/os.update.part.jinja2
@@ -1,2 +1,2 @@
-group: {{item.osConfig.channel}}
+group: {{ item.osConfig.channel | default("") }}
 reboot-strategy: etcd-lock

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -102,10 +102,16 @@ definitions:
     - &defaultCoreOs
       name: defaultCoreOs
       kind: os
-      type: coreOs
+      type: coreos
       version: current
       channel: stable
       rebootStrategy: "off"
+    - &defaultUbuntu
+      name: defaultUbuntu
+      kind: os
+      type: ubuntu
+      version: 16.04
+      subversion: latest
   nodeConfigs:
     - &defaultAwsEtcdNode
       name: defaultAwsEtcdNode

--- a/ansible/roles/kraken.config/files/schema/v1alpha.json
+++ b/ansible/roles/kraken.config/files/schema/v1alpha.json
@@ -330,8 +330,8 @@
                 },
                 "type": {
                     "description": "Operating System distribution",
-                    "enum": [ "coreOs" ],
-                    "default": "coreOs",
+                    "enum": [ "coreos" ],
+                    "default": "coreos",
                     "type": "string"
                 },
                 "channel": {
@@ -360,6 +360,42 @@
             ],
             "type": "object"
         },
+        "UbuntuOsConfig": {
+            "description": "CoreOS specific configuration",
+            "properties": {
+                "name": {
+                    "description": "Name of the Ubuntu configuration",
+                    "default": "defaultUbuntuConfig",
+                    "type": "string"
+                },
+                "kind": {
+                    "default": "osConfig",
+                    "description": "Location of the Kubernetes container.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Operating System distribution",
+                    "enum": [ "ubuntu" ],
+                    "default": "ubunu",
+                    "type": "string"
+                },
+                "version": {
+                    "default": "16.04",
+                    "description": "Location of the Kubernetes container.", 
+                    "type": "string"
+                }
+                "subversion": {
+                    "default": "latest"
+                    "description": "The release version of the distro version"
+                    "type": "string"
+            },
+            "required": [
+                "type",
+                "version"
+            ],
+            "type": "object"
+        },
+
 
         "nodeConfig": {
             "//": "Once the node schema are defined, consider changing anyOf to oneOf",

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
@@ -69,13 +69,19 @@ resource "aws_security_group" "vpc_etcd_{{node.name}}_secgroup" {
 {% if node.etcdConfig is defined %}
 data "distro_image" "{{ node.name }}_ami" {
   cloud_provider = "aws"
-  distribution   = "{{ node.osConfig.type}}"
-  channel        = "{{ node.osConfig.channel | default(omit) }}"
+  distribution   = "{{ node.osConfig.type }}"
   virtualization = "hvm"
   region         = "{{ cluster.providerConfig.region }}"
+{% if node.osConfig.store is defined -%}
+  store          = "ssd"
+{% endif %}
+{% if node.osConfig.channel is defined -%}
+  channel        = "{{ node.osConfig.channel }}"
+{% endif %}
   version        = "{{ node.osConfig.version }}"
-  store          = "{{ node.osConfig.store | default(omit) }}"
-  subversion     = "{{ node.osConfig.subversion | default(omit) }}"
+{% if node.osConfig.subversion is defined %}
+  subversion     = "{{ node.osConfig.subversion }}"
+{% endif %}
 }
 {% endif %}
 {% endfor %}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
@@ -69,7 +69,7 @@ resource "aws_security_group" "vpc_etcd_{{node.name}}_secgroup" {
 {% if node.etcdConfig is defined %}
 data "distro_image" "{{ node.name }}_ami" {
   cloud_provider = "aws"
-  distribution   = "{{ node.osConfig.distro }}"
+  distribution   = "{{ node.osConfig.type}}"
   channel        = "{{ node.osConfig.channel | default(omit) }}"
   virtualization = "hvm"
   region         = "{{ cluster.providerConfig.region }}"

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
@@ -67,11 +67,15 @@ resource "aws_security_group" "vpc_etcd_{{node.name}}_secgroup" {
 # information on CoreOS AMIs for etcd nodepools
 {% for node in cluster.nodePools %}
 {% if node.etcdConfig is defined %}
-resource "coreosbox_ami" "{{node.name}}_ami" {
-  channel        = "{{node.osConfig.channel}}"
+data "distro_image" "{{ node.name }}_ami" {
+  cloud_provider = "aws"
+  distribution   = "{{ node.osConfig.distro }}"
+  channel        = "{{ node.osConfig.channel | default(omit) }}"
   virtualization = "hvm"
-  region         = "{{cluster.providerConfig.region}}"
-  version        = "{{node.osConfig.version}}"
+  region         = "{{ cluster.providerConfig.region }}"
+  version        = "{{ node.osConfig.version }}"
+  store          = "{{ node.osConfig.store | default(omit) }}"
+  subversion     = "{{ node.osConfig.subversion | default(omit) }}"
 }
 {% endif %}
 {% endfor %}
@@ -82,13 +86,13 @@ resource "coreosbox_ami" "{{node.name}}_ami" {
 {% if node.etcdConfig is defined %}
 {% for node_idx in range(1, node.count+1)%}
 resource "aws_instance" "{{node.name}}_{{node_idx}}" {
-  ami                         = "${coreosbox_ami.{{node.name}}_ami.box_string}"
-  instance_type               = "{{node.nodeConfig.providerConfig.type}}"
-  key_name                    = "${var.{{node.keyPair.name}}_{{node.name}}_key}"
-  vpc_security_group_ids      = ["${aws_security_group.vpc_etcd_{{node.name}}_secgroup.id}"]
-  user_data                   = "${file("{{ config_base | expanduser }}/{{cluster.name}}/cloud-config/{{node.name}}.cloud-config.yaml")}"
+  ami                         = "${ data.distro_image.{{ node.name }}_ami.output_path }"
+  instance_type               = "{{ node.nodeConfig.providerConfig.type }}"
+  key_name                    = "${ var.{{ node.keyPair.name }}_{{ node.name }}_key }"
+  vpc_security_group_ids      = ["${ aws_security_group.vpc_etcd_{{ node.name }}_secgroup.id }"]
+  user_data                   = "${ file("{{ config_base | expanduser }}/{{ cluster.name }}/cloud-config/{{ node.name }}.cloud-config.yaml") }"
   associate_public_ip_address = true
-  subnet_id                   = "${var.{{node.nodeConfig.providerConfig.subnet[ node_idx % node.nodeConfig.providerConfig.subnet|count ]}}_{{node.name}}_subnet_id}"
+  subnet_id                   = "${ var.{{ node.nodeConfig.providerConfig.subnet[ node_idx % node.nodeConfig.providerConfig.subnet | count ] }}_{{ node.name }}_subnet_id }"
 
 # storage
 {% for storage in node.nodeConfig.providerConfig.storage %}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -17,12 +17,18 @@ variable "dependency" {}
 data "distro_image" "{{ node.name }}_ami" {
   cloud_provider = "aws"
   distribution   = "{{ node.osConfig.type }}"
-  channel        = "{{ node.osConfig.channel | default(omit) }}"
   virtualization = "hvm"
   region         = "{{ cluster.providerConfig.region }}"
+{% if node.osConfig.store is defined -%}
+  store          = "ssd"
+{% endif %}
+{% if node.osConfig.channel is defined -%}
+  channel        = "{{ node.osConfig.channel }}"
+{% endif %}
   version        = "{{ node.osConfig.version }}"
-  store          = "{{ node.osConfig.store | default(omit) }}"
-  subversion     = "{{ node.osConfig.subversion | default(omit) }}"
+{% if node.osConfig.subversion is defined %}
+  subversion     = "{{ node.osConfig.subversion }}"
+{% endif %}
 }
 
 # IAM roles and policies for kubernetes cloud provider

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -14,11 +14,15 @@ variable "route53_zone_id" {}
 variable "kubernetes_sec_group" {}
 variable "dependency" {}
 
-resource "coreosbox_ami" "master_ami" {
-  channel        = "{{master.osConfig.channel}}"
+data "distro_image" "{{ node.name }}_ami" {
+  cloud_provider = "aws"
+  distribution   = "{{ node.osConfig.distro }}"
+  channel        = "{{ node.osConfig.channel | default(omit) }}"
   virtualization = "hvm"
-  region         = "{{cluster.providerConfig.region}}"
-  version        = "{{master.osConfig.version}}"
+  region         = "{{ cluster.providerConfig.region }}"
+  version        = "{{ node.osConfig.version }}"
+  store          = "{{ node.osConfig.store | default(omit) }}"
+  subversion     = "{{ node.osConfig.subversion | default(omit) }}"
 }
 
 # IAM roles and policies for kubernetes cloud provider
@@ -82,14 +86,14 @@ resource "aws_iam_instance_profile" "kubernetes_master_profile" {
 
 # Launch configuration for master
 resource "aws_launch_configuration" "master_launch_config" {
-  name_prefix                 = "${var.master_name}_master"
-  image_id                    = "${coreosbox_ami.master_ami.box_string}"
-  key_name                    = "${var.master_key_name}"
-  instance_type               = "{{master.nodeConfig.providerConfig.type}}"
-  security_groups             = ["${var.kubernetes_sec_group}"]
+  name_prefix                 = "${ var.master_name }_master"
+  image_id                    = "${ data.distro_image.{{  node.name  }}_ami.output_path }"
+  key_name                    = "${ var.master_key_name }"
+  instance_type               = "{{ master.nodeConfig.providerConfig.type }}"
+  security_groups             = ["${ var.kubernetes_sec_group }"]
   associate_public_ip_address = true
-  iam_instance_profile        = "${aws_iam_instance_profile.kubernetes_master_profile.name}"
-  user_data                   = "${file("{{ config_base | expanduser }}/{{cluster.name}}/cloud-config/{{master.name}}.cloud-config.yaml")}"
+  iam_instance_profile        = "${ aws_iam_instance_profile.kubernetes_master_profile.name }"
+  user_data                   = "${ file("{{  config_base | expanduser  }}/{{ cluster.name }}/cloud-config/{{ master.name }}.cloud-config.yaml") }"
 
   lifecycle {
     create_before_destroy = true
@@ -186,16 +190,16 @@ resource "aws_route53_record" "dex_record" {
 {% else %}
 # Launch configuration for master loadbalancer
 resource "aws_launch_configuration" "master_loadbalancer_launch_config" {
-  name_prefix                 = "${var.master_name}_loadbalancer"
-  image_id                    = "${coreosbox_ami.master_ami.box_string}"
-  key_name                    = "${var.master_key_name}"
-  instance_type               = "{{master.nodeConfig.providerConfig.type}}"
-  security_groups             = ["${var.kubernetes_sec_group}"]
+  name_prefix                 = "${ var.master_name }_loadbalancer"
+  image_id                    = "${ data.distro_image.{{  node.name  }}_ami.output_path }"
+  key_name                    = "${ var.master_key_name }"
+  instance_type               = "{{ master.nodeConfig.providerConfig.type }}"
+  security_groups             = ["${ var.kubernetes_sec_group }"]
   associate_public_ip_address = true
 
   lifecycle {
     create_before_destroy = true
-  }
+   }
 
   #TODO
   user_data                   = ""

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -16,7 +16,7 @@ variable "dependency" {}
 
 data "distro_image" "{{ node.name }}_ami" {
   cloud_provider = "aws"
-  distribution   = "{{ node.osConfig.distro }}"
+  distribution   = "{{ node.osConfig.type }}"
   channel        = "{{ node.osConfig.channel | default(omit) }}"
   virtualization = "hvm"
   region         = "{{ cluster.providerConfig.region }}"

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
@@ -82,11 +82,13 @@ resource "aws_iam_instance_profile" "kubernetes_node_profile" {
 # information on CoreOS AMIs for node nodepools
 {% for node in cluster.nodePools %}
 {% if node.etcdConfig is not defined and node.apiServerConfig is not defined %}
-resource "coreosbox_ami" "{{node.name}}_ami" {
-  channel        = "{{node.osConfig.channel}}"
+data "distro_image" "{{ etcd.name }}_ami" {
+  cloud_provider = "aws"
+  distribution   = "ubuntu"
   virtualization = "hvm"
-  region         = "{{cluster.providerConfig.region}}"
-  version        = "{{node.osConfig.version}}"
+  store          = "ssd"
+  region         = "{{ kraken_config.providerConfig.region }}"
+  version        = "{{ etcd.nodepool.ubuntu.version }}"
 }
 {% endif %}
 {% endfor %}
@@ -95,15 +97,15 @@ resource "coreosbox_ami" "{{node.name}}_ami" {
 # Launch configurations for all node pools
 {% for node in cluster.nodePools %}
 {% if node.etcdConfig is not defined and node.apiServerConfig is not defined %}
-resource "aws_launch_configuration" "{{node.name}}_launch_config" {
-  name_prefix                 = "${var.nodes_name}_{{node.name}}"
-  image_id                    = "${coreosbox_ami.{{node.name}}_ami.box_string}"
-  key_name                    = "${var.{{node.keyPair.name}}_{{node.name}}_key}"
-  instance_type               = "{{node.nodeConfig.providerConfig.type}}"
-  security_groups             = ["${var.kubernetes_sec_group}"]
+resource "aws_launch_configuration" "{{ node.name }}_launch_config" {
+  name_prefix                 = "${ var.nodes_name }_{{ node.name }}"
+  image_id                    = "${ data.distro_image.{{ node.name }}_ami.output_path }"
+  key_name                    = "${ var.{{ node.keyPair.name }}_{{ node.name }}_key }"
+  instance_type               = "{{ node.nodeConfig.providerConfig.type }}"
+  security_groups             = ["${ var.kubernetes_sec_group }"]
   associate_public_ip_address = true
-  iam_instance_profile        = "${aws_iam_instance_profile.kubernetes_node_profile.name}"
-  user_data                   = "${file("{{ config_base | expanduser }}/{{cluster.name}}/cloud-config/{{node.name}}.cloud-config.yaml")}"
+  iam_instance_profile        = "${ aws_iam_instance_profile.kubernetes_node_profile.name }"
+  user_data                   = "${ file("{{  config_base | expanduser  }}/{{ cluster.name }}/cloud-config/{{ node.name }}.cloud-config.yaml") }"
 
   lifecycle {
     create_before_destroy = true

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
@@ -84,11 +84,17 @@ resource "aws_iam_instance_profile" "kubernetes_node_profile" {
 {% if node.etcdConfig is not defined and node.apiServerConfig is not defined %}
 data "distro_image" "{{ etcd.name }}_ami" {
   cloud_provider = "aws"
-  distribution   = "ubuntu"
+  distribution   = "{{ node.osConfig.type }}"
   virtualization = "hvm"
   store          = "ssd"
-  region         = "{{ kraken_config.providerConfig.region }}"
-  version        = "{{ etcd.nodepool.ubuntu.version }}"
+  region         = "{{ cluster.providerConfig.region }}"
+{% if node.osConfig.channel is defined -%}
+  channel        = "{{ node.osConfig.channel }}"
+{%- endif %}
+  version        = "{{ node.osConfig.version }}"
+{% if node.osConfig.subversion is defined -%}
+  subversion     = "{{ node.osConfig.subversion | default(omit) }}"
+{%- endif %}
 }
 {% endif %}
 {% endfor %}
@@ -170,3 +176,4 @@ resource "aws_autoscaling_group" "{{node.name}}_nodes" {
 }
 {% endif %}
 {% endfor %}
+#}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
@@ -82,19 +82,21 @@ resource "aws_iam_instance_profile" "kubernetes_node_profile" {
 # information on CoreOS AMIs for node nodepools
 {% for node in cluster.nodePools %}
 {% if node.etcdConfig is not defined and node.apiServerConfig is not defined %}
-data "distro_image" "{{ etcd.name }}_ami" {
+data "distro_image" "{{ node.name }}_ami" {
   cloud_provider = "aws"
   distribution   = "{{ node.osConfig.type }}"
   virtualization = "hvm"
-  store          = "ssd"
   region         = "{{ cluster.providerConfig.region }}"
+{% if node.osConfig.store is defined -%}
+  store          = "ssd"
+{% endif %}
 {% if node.osConfig.channel is defined -%}
   channel        = "{{ node.osConfig.channel }}"
-{%- endif %}
+{% endif %}
   version        = "{{ node.osConfig.version }}"
-{% if node.osConfig.subversion is defined -%}
-  subversion     = "{{ node.osConfig.subversion | default(omit) }}"
-{%- endif %}
+{% if node.osConfig.subversion is defined %}
+  subversion     = "{{ node.osConfig.subversion }}"
+{% endif %}
 }
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This allows you to use defaultUbuntu instead of defaultCoreOS to boot up machines on aws.

Issue #157