### PR TITLE
update defaults for central-logging

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -9,7 +9,7 @@ definitions:
       kubedns:
         cluster_ip: 10.32.0.2
         dns_domain: cluster.local
-        namsepace: kube-system 
+        namsepace: kube-system
   helmConfigs:
     - &defaultHelm
       name: defaultHelm
@@ -147,7 +147,7 @@ definitions:
               snapshot_id:
               encrypted: false
     - &defaultAwsEtcdEventsNode
-      name: defaultAwsEtcdEventsNode 
+      name: defaultAwsEtcdEventsNode
       kind: node
       mounts:
         -
@@ -221,7 +221,7 @@ definitions:
           forceFormat: true
       providerConfig:
         provider: aws
-        type: c4.large
+        type: m4.xlarge
         subnet: ["uwswest2a", "uwswest2b", "uwswest2c"]
         tags:
           -
@@ -324,7 +324,7 @@ definitions:
           to_port: 0
           protocol: "-1"
           cidr_blocks: ["0.0.0.0/0"]
- 
+
   keyPairs:
    - &defaultKeyPair
       name: defaultKeyPair
@@ -346,7 +346,7 @@ definitions:
 
 deployment:
   clusters:
-    - name: 
+    - name:
       network: 10.32.0.0/12
       dns: 10.32.0.2
       domain: cluster.local
@@ -375,7 +375,7 @@ deployment:
           nodeConfig: *defaultAwsMasterNode
           keyPair: *defaultKeyPair
         - name: clusterNodes
-          count: 3
+          count: 6
           kubeConfig: *defaultKube
           containerConfig: *defaultDocker
           osConfig: *defaultCoreOs
@@ -396,4 +396,3 @@ deployment:
     type: exact
     value: 0
     wait: 600
-    

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -9,7 +9,7 @@ definitions:
       kubedns:
         cluster_ip: 10.35.240.10
         dns_domain: cluster.local
-        namsepace: kube-system 
+        namsepace: kube-system
   helmConfigs:
     - &defaultHelm
       name: defaultHelm
@@ -76,7 +76,7 @@ definitions:
       kind: node
       providerConfig:
         diskSize: 100
-        machineType: n1-standard-1
+        machineType: n1-standard-16
         scopes:
           - https://www.googleapis.com/auth/compute
           - https://www.googleapis.com/auth/devstorage.read_only
@@ -97,7 +97,7 @@ definitions:
    - &defaultGKEKeyPair
       name: defaultGKEKeyPair
       kind: keyPair
-      providerConfig: 
+      providerConfig:
         serviceAccount: patrickrobot@k8s-work.iam.gserviceaccount.com
         serviceAccountKeyFile:  /kraken/patrickRobot.json
   kubeAuth:
@@ -119,7 +119,7 @@ definitions:
       keypair: *defaultGKEKeyPair
       zone:
         primaryZone: us-central1-a
-        additionalZones: 
+        additionalZones:
           - us-central1-b
           - us-central1-c
 
@@ -135,7 +135,7 @@ deployment:
       kubeAuth: *defaultKubeAuth
       nodePools:
         - name: clusternodes
-          count: 3
+          count: 6
           kubeConfig: *defaultKube
           nodeConfig: *defaultGKEClusterNode
         - name: othernodes


### PR DESCRIPTION
the inclusion by default of the central-logging repo means that several specs needed to get updated. We needed more clusterNodes slightly different instance types to handle logging