### PR TITLE
all letters need be lowercase because of GKE

### DIFF
--- a/build-scripts/update-generated-config.sh
+++ b/build-scripts/update-generated-config.sh
@@ -5,7 +5,7 @@
 
 set -x
 
-cluster_name=`echo $2 | tr -cd '[[:alnum:]]-'`
+cluster_name=`echo $2 | tr -cd '[[:alnum:]]-' | tr '[:upper:]' '[:lower:]'`
 
 #  old style configs (can be removed after k2recon is merged)
 sed -i -e "s/cluster:/cluster: ${cluster_name}/" $1


### PR DESCRIPTION
GKE only accepts lower case letters in the cluster names.  AWS is fine either way so we're going to constrain to GKE levels.