### PR TITLE
Update readme versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ You will need to have the following:
 You will need the following installed on your machine:
 
 - Python 2.x (virtualenv strongly suggested)
- - pip
- - boto
- - netaddr
+  - pip
+  - boto
+  - netaddr
 - Ansible ([see k2-tools](https://github.com/samsung-cnct/k2-tools/blob/master/requirements.txt) for the version)
 - Cloud SDKs
- - aws cli
- - gcloud SDK
+  - aws cli
+  - gcloud SDK
 - Terraform and Providers ([see k2-tools](https://github.com/samsung-cnct/k2-tools/blob/master/Dockerfile) for the versions)
  - Terraform
  - Terraform Execute Provider (https://github.com/samsung-cnct/terraform-provider-execute/releases)  

--- a/README.md
+++ b/README.md
@@ -49,20 +49,19 @@ You will need to have the following:
 You will need the following installed on your machine:
 
 - Python 2.x (virtualenv strongly suggested)
-  - pip
-  - boto
-  - netaddr
-- Ansible 2.2.x
+ - pip
+ - boto
+ - netaddr
+- Ansible ([see k2-tools](https://github.com/samsung-cnct/k2-tools/blob/master/requirements.txt) for the version)
 - Cloud SDKs
-  - aws cli
-  - gcloud SDK
-- Terraform and providers
-  - Terraform 0.8.6
-  - Terraform execute provider 0.0.4 (https://github.com/samsung-cnct/terraform-provider-execute/releases)  
-  - Terraform coreosbox provider 0.0.3 (https://github.com/samsung-cnct/terraform-provider-coreosbox/releases)
+ - aws cli
+ - gcloud SDK
+- Terraform and Providers ([see k2-tools](https://github.com/samsung-cnct/k2-tools/blob/master/Dockerfile) for the versions)
+ - Terraform
+ - Terraform Execute Provider (https://github.com/samsung-cnct/terraform-provider-execute/releases)  
+ - Terraform Coreosbox Provider (https://github.com/samsung-cnct/terraform-provider-coreosbox/releases)
 - kubectl 1.3.x
 - helm alpha.5 or later
-
 
 ## The K2 image
 


### PR DESCRIPTION
This a proposed solution to the problem observed in k2-tools/#43. Really the links should point to a tagged release to ensure they never break.