### PR TITLE
allow e2e tests to succeed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 podTemplate(label: 'k2', containers: [
     containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
     containerTemplate(name: 'k2-tools', image: 'quay.io/samsung_cnct/k2-tools:latest', ttyEnabled: true, command: 'cat'),
-    containerTemplate(name: 'e2e-tester', image: 'quay.io/samsung_cnct/e2etester:0.1', ttyEnabled: true, command: 'cat'),
+    containerTemplate(name: 'e2e-tester', image: 'quay.io/samsung_cnct/e2etester:0.2', ttyEnabled: true, command: 'cat'),
     containerTemplate(name: 'docker', image: 'docker', command: 'cat', ttyEnabled: true)
   ], volumes: [
     hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock'),
@@ -42,7 +42,7 @@ podTemplate(label: 'k2', containers: [
                     } finally {
                         container('k2-tools') {
                             stage('destroy k2 cluster') {
-                                sh 'PWD=`pwd` && ./down.sh --config $PWD/cluster/aws/config.yaml --output $PWD/cluster/aws/'                        
+                                sh 'PWD=`pwd` && ./down.sh --config $PWD/cluster/aws/config.yaml --output $PWD/cluster/aws/ || true'                        
                                 junit "output/artifacts/*.xml"                                
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 podTemplate(label: 'k2', containers: [
     containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
     containerTemplate(name: 'k2-tools', image: 'quay.io/samsung_cnct/k2-tools:latest', ttyEnabled: true, command: 'cat'),
-    containerTemplate(name: 'e2e-tester', image: 'quay.io/samsung_cnct/e2etester:0.2', ttyEnabled: true, command: 'cat'),
+    containerTemplate(name: 'e2e-tester', image: 'quay.io/samsung_cnct/e2etester:0.2', ttyEnabled: true, command: 'cat', alwaysPullImage: true),
     containerTemplate(name: 'docker', image: 'docker', command: 'cat', ttyEnabled: true)
   ], volumes: [
     hostPathVolume(hostPath: '/var/run/docker.sock', mountPath: '/var/run/docker.sock'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,8 @@ podTemplate(label: 'k2', containers: [
                     } finally {
                         container('k2-tools') {
                             stage('destroy k2 cluster') {
-                                junit "output/artifacts/*.xml"
                                 sh 'PWD=`pwd` && ./down.sh --config $PWD/cluster/aws/config.yaml --output $PWD/cluster/aws/'                        
+                                junit "output/artifacts/*.xml"                                
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 podTemplate(label: 'k2', containers: [
     containerTemplate(name: 'jnlp', image: 'jenkinsci/jnlp-slave:2.62-alpine', args: '${computer.jnlpmac} ${computer.name}'),
-    containerTemplate(name: 'k2-tools', image: 'quay.io/samsung_cnct/k2-tools:latest', ttyEnabled: true, command: 'cat'),
+    containerTemplate(name: 'k2-tools', image: 'quay.io/samsung_cnct/k2-tools:latest', ttyEnabled: true, command: 'cat', alwaysPullImage: true),
     containerTemplate(name: 'e2e-tester', image: 'quay.io/samsung_cnct/e2etester:0.2', ttyEnabled: true, command: 'cat', alwaysPullImage: true),
     containerTemplate(name: 'docker', image: 'docker', command: 'cat', ttyEnabled: true)
   ], volumes: [

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -20,11 +20,6 @@ definitions:
         - name: stable
           url: https://kubernetes-charts.storage.googleapis.com
       charts:
-        - name: heapster
-          repo: atlas
-          chart: heapster
-          version: 0.1.0
-          namespace: kube-system
         - name: central-logging
           repo: atlas
           chart: central-logging

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -113,10 +113,10 @@ definitions:
       project: k8s-work
       keypair: *defaultGKEKeyPair
       zone:
-        primaryZone: us-central1-a
+        primaryZone: us-east1-a
         additionalZones:
-          - us-central1-b
-          - us-central1-c
+          - us-east1-b
+          - us-east1-c
 
 # This is the core of the new configuration.
 

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -113,10 +113,10 @@ definitions:
       project: k8s-work
       keypair: *defaultGKEKeyPair
       zone:
-        primaryZone: us-east1-a
+        primaryZone: us-east1-b
         additionalZones:
-          - us-east1-b
           - us-east1-c
+          - us-east1-d
 
 # This is the core of the new configuration.
 

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -135,7 +135,7 @@ deployment:
       kubeAuth: *defaultKubeAuth
       nodePools:
         - name: clusternodes
-          count: 6
+          count: 2
           kubeConfig: *defaultKube
           nodeConfig: *defaultGKEClusterNode
         - name: othernodes

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -113,7 +113,7 @@ definitions:
       project: k8s-work
       keypair: *defaultGKEKeyPair
       zone:
-        primaryZone: us-centra11-a
+        primaryZone: us-central1-a
         additionalZones:
           - us-central1-b
           - us-central1-c

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -113,10 +113,10 @@ definitions:
       project: k8s-work
       keypair: *defaultGKEKeyPair
       zone:
-        primaryZone: us-east1-b
+        primaryZone: us-centra11-a
         additionalZones:
-          - us-east1-c
-          - us-east1-d
+          - us-central1-b
+          - us-central1-c
 
 # This is the core of the new configuration.
 

--- a/build-scripts/conformance-tests.sh
+++ b/build-scripts/conformance-tests.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -x
 
 #  prep the local container with the test files

--- a/build-scripts/conformance-tests.sh
+++ b/build-scripts/conformance-tests.sh
@@ -27,7 +27,7 @@ export GOPATH="${PWD}/go"
 mkdir -p "${GOPATH}"
 
 ## run
-K2_CLUSTER_NAME=`echo $2 | tr -cd '[[:alnum:]]-'`
+K2_CLUSTER_NAME=`echo $2 | tr -cd '[[:alnum:]]-' | tr '[:upper:]' '[:lower:]'`
 export KUBE_CONFORMANCE_KUBECONFIG=${PWD}/cluster/aws/${K2_CLUSTER_NAME}/admin.kubeconfig
 export KUBE_CONFORMANCE_OUTPUT_DIR=${OUTPUT_DIR}/artifacts
 

--- a/build-scripts/conformance-tests.sh
+++ b/build-scripts/conformance-tests.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -x
 
 #  prep the local container with the test files

--- a/build-scripts/conformance-tests.sh
+++ b/build-scripts/conformance-tests.sh
@@ -32,9 +32,8 @@ export KUBE_CONFORMANCE_KUBECONFIG=${PWD}/cluster/aws/${K2_CLUSTER_NAME}/admin.k
 export KUBE_CONFORMANCE_OUTPUT_DIR=${OUTPUT_DIR}/artifacts
 
 # TODO: unclear what part of k8s scripts require USER to be set
-KUBERNETES_PROVIDER=aws USER=jenkins ${PWD}/hack/parallel-conformance.sh ${target_dir} | tee ${OUTPUT_DIR}/build-log.txt
-# tee isn't exiting >0 as expected, so use the exit status of the script directly
-conformance_result=${PIPESTATUS[0]}
+KUBERNETES_PROVIDER=aws USER=jenkins ${PWD}/hack/parallel-conformance.sh ${target_dir}
+conformance_result=$?
 
 # clean up scratch space
 rm -rf $3/*

--- a/build-scripts/e2etester-docker/Makefile
+++ b/build-scripts/e2etester-docker/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG = 0.1
+TAG = 0.2
 PREFIX = quay.io/samsung_cnct/e2etester
 
 container:


### PR DESCRIPTION
the 'tee' portion in a command (and subsequent workarounds) were causing all runs to fail.  I believe the PIPESTATUS workaround is not available in the sh shell.  we no longer need to save off the build-log output file.

removal of this guff has produced at least one e2e successful run.  This PR should not be merged until the new jenkins job passes.