### PR TITLE
Update README.md, mostly to use ${CLUSTER}.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ deployment:
     - name: YOURCLUSTER
 ```
 
-Should should then rename the `config.yaml` file to `YOURCLUSTER.yaml`.  This is best practice.
+You should then rename the `config.yaml` file to `YOURCLUSTER.yaml`.  This is best practice.
 
 **For the rest of the discussion, we will assume that the environmental variable `${CLUSTER}` has been set to the name of your cluster.**
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This will generate a config.yaml file located at
 ```
 ${KRAKEN}/config.yaml
 ```
-In discussions that follow, the variable `YOURCLUSTER` refers to the name you must assign to your cluster at the bottom of the generated `config.yaml` in the deployments section, which once a name has been decided would look like:
+In this section, the variable `YOURCLUSTER` refers to the name you must assign to your cluster at the bottom of the generated `config.yaml` in the deployments section, which once a name has been decided would look like:
 
 ```
 deployment:
@@ -118,11 +118,14 @@ deployment:
     - name: YOURCLUSTER
 ```
 
-Finally, we suggest you rename the `config.yaml` file to something like
+We suggest you rename the `config.yaml` file to something like
 
 ```
 YOURCLUSTER.yaml
 ```
+
+**For the rest of the discussion, we will assume that the environmental variable `${CLUSTER}` has been set to the name of your cluster**
+
 
 It is particularly useful when trying to create and manage multiple clusters, each of which
 **must** have unique names.
@@ -145,33 +148,42 @@ using the local awscli tool:
  aws configure
 ```
 
+### Creating your cluster
+
+To bring your cluster up, run:
+```bash
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/${CLUSTER}.yaml
+```
+
+This will take a while, and will generate a lot of output.
+
 ### kubectl
 
-After creating a cluster, to use the kubectl shipped with K2, run a command similar to:
+After creating a cluster, to use the kubectl shipped with K2, run:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig $HOME/.kraken/YOURCLUSTER/admin.kubeconfig get nodes
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig $HOME/.kraken/${CLUSTER}/admin.kubeconfig get nodes
 ```
 
 with locally installed kubectl:
 
 ```bash
-`kubectl --kubeconfig ~/.kraken/YOURCLUSTER/admin.kubeconfig get nodes`
+`kubectl --kubeconfig ~/.kraken/${CLUSTER}/admin.kubeconfig get nodes`
 ```
 
 ### helm
 
-After creating a cluster, to use the helm shipped with K2, run a command similar to:
+After creating a cluster, to use the helm shipped with K2, run:
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/YOURCLUSTER/.helm -e KUBECONFIG=$HOME/.kraken/YOURCLUSTER/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm list
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm list
 ```
 
 with locally installed kubectl:
 
 ```bash
-export KUBECONFIG=~/.kraken/YOURCLUSTER/admin.kubeconfig
-`helm list --home ~/.kraken/YOURCLUSTER/.helm`
+export KUBECONFIG=~/.kraken/${CLUSTER}/admin.kubeconfig
+`helm list --home ~/.kraken/${CLUSTER}/.helm`
 ```
 
 ### ssh
@@ -179,13 +191,13 @@ export KUBECONFIG=~/.kraken/YOURCLUSTER/admin.kubeconfig
 After creating a cluster you should be able to ssh to various cluster nodes
 
 ```bash
-ssh master-3 -F ~/.kraken/YOURCLUSTER/ssh_config
+ssh master-3 -F ~/.kraken/${CLUSTER}/ssh_config
 ```
 
 Cluster creating process generates an ssh config file at
 
 ```bash
- ~/.kraken/YOURCLUSTER/ssh_config
+ ~/.kraken/${CLUSTER}/ssh_config
 ```
 
 Host names are based on node pool names from your config file. I.e. if you had a config file with nodepool section like so:
@@ -221,8 +233,6 @@ Then the ssh hostnames available will be:
 
 Earlier, you copied a sample cluster configuration over into `~/.kraken`.  Please take a moment to review the sample configuration and make changes if you desire
 
-You may prefer to save it with a name that is consistent with the `cluster` variable in the configuration. In other words, if your `cluster` is `foo`, then perhaps your file should be named `foo.yaml`
-
 ### Important configuration variables to adjust
 
 While all configuration options are available for a reason, some are more important than others.  Some key ones include
@@ -244,10 +254,8 @@ For a detailed explanation of all configuration variables, please consult [our c
 To boot up a cluster per your configuration, please execute the following command:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/${CLUSTER}.yaml
 ```
-
-Replace `foo.yaml` with the name of the configuration file you intended to use
 
 Normally K2 will take a look at your configuration, generate artifacts like cloud-config files, and deploy VMs that will become your cluster.
 
@@ -259,12 +267,10 @@ The amount of time it will take to deploy a new cluster is variable, but expect 
 
 After K2 has run, you should have a working cluster waiting for workloads. To verify it is functional, run the commands described in this section.
 
-You will need to change `cluster` configuration value from `foo` to the value specified in your configuration.
-
 #### Getting Kubernetes Nodes
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig get nodes
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/${CLUSTER}/admin.kubeconfig get nodes
 ```
 
 The result should resemble the following:
@@ -284,13 +290,18 @@ ip-10-0-65-77.us-west-2.compute.internal     Ready                      2m
 #### Getting Kubernetes Deployments
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig get deployments --all-namespaces
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/${CLUSTER}/admin.kubeconfig get deployments --all-namespaces
 ```
 
 ```bash
-NAMESPACE     NAME            DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-kube-system   kube-dns        1         1         1            1           8m
-kube-system   tiller-deploy   1         1         1            1           8m
+NAMESPACE     NAME                         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+default       central-fluentd-deployment   3         3         3            3           3m
+default       kafka-monitor                1         1         1            1           3m
+default       kibana-logging               3         3         3            3           3m
+kube-system   heapster-standalone          1         1         1            1           3m
+kube-system   kube-dns                     1         1         1            1           3m
+kube-system   tiller-deploy                1         1         1            1           3m
+
 ```
 
 #### Deploy a new service
@@ -302,34 +313,34 @@ You can try having helm install a new service, such as the Kubernetes dashboard
 ##### Find Kubernetes Dashboard Version
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/foo/.helm -e KUBECONFIG=$HOME/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes-dashboard
 
-$ atlas/kubernetes-dashboard-0.1.0.tgz
+NAME                      	VERSION	DESCRIPTION                      
+atlas/kubernetes-dashboard	0.1.0  	A kubernetes dashboard Helm chart
 ```
 
-This indicates that the file to install is `atlas/kubernetes-dashboard-0.1.0`.
+This indicates that the file to install is `atlas/kubernetes-dashboard`.
 
 ##### Install Kubernetes Dashboard
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/foo/.helm -e KUBECONFIG=$HOME/.kraken/foo/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install atlas/kubernetes-dashboard-0.1.0
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install --namespace kube-system atlas/kubernetes-dashboard
 ```
 
 ```bash
-Fetched atlas/kubernetes-dashboard-0.1.0 to /kraken/kubernetes-dashboard-0.1.0.tgz
-foolhardy-scorpion
-Last Deployed: Wed Oct  5 16:20:42 2016
-Namespace:
-Status: DEPLOYED
+NAME:   innocent-olm
+LAST DEPLOYED: Thu May 18 22:04:03 2017
+NAMESPACE: kube-system
+STATUS: DEPLOYED
 
-Resources:
-==> extensions/Deployment
-NAME                   DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-kubernetes-dashboard   1         1         1            0           1s
-
+RESOURCES:
 ==> v1/Service
-NAME                   CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
-kubernetes-dashboard   10.37.204.191   <pending>     80/TCP    1s
+NAME                  CLUSTER-IP     EXTERNAL-IP  PORT(S)       AGE
+kubernetes-dashboard  10.46.101.182  <pending>    80:31999/TCP  0s
+
+==> extensions/v1beta1/Deployment
+NAME                  DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
+kubernetes-dashboard  1        1        1           0          0s
 ```
 
 The chart has been installed. It will take a moment for AWS ELB DNS to propagate, but you can get the DNS now.
@@ -337,29 +348,29 @@ The chart has been installed. It will take a moment for AWS ELB DNS to propagate
 ##### Finding DNS name for Kubernetes Dashboard
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/foo/admin.kubeconfig describe service kubernetes-dashboard --namespace kube-system
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig ~/.kraken/${CLUSTER}/admin.kubeconfig describe service kubernetes-dashboard --namespace kube-system
 ```
 
 ```bash
-Name:     kubernetes-dashboard
-Namespace:    kube-system
-Labels:     app=kubernetes-dashboard
-Selector:   app=kubernetes-dashboard
-Type:     LoadBalancer
-IP:     10.37.204.191
-LoadBalancer Ingress: aa95470398b1711e6b3a706da4d1c1f9-1324035908.us-west-2.elb.amazonaws.com
-Port:     <unset> 80/TCP
-NodePort:   <unset> 31638/TCP
-Endpoints:    10.128.36.2:9090
-Session Affinity: None
+Name:			kubernetes-dashboard
+Namespace:		kube-system
+Labels:			app=kubernetes-dashboard
+Selector:		app=kubernetes-dashboard
+Type:			LoadBalancer
+IP:			10.46.101.182
+LoadBalancer Ingress:	ae7a0bae03c1511e78f8f06148e55c0f-1296896684.us-west-2.elb.amazonaws.com
+Port:			<unset>	80/TCP
+NodePort:		<unset>	31999/TCP
+Endpoints:		10.129.84.6:9090
+Session Affinity:	None
 Events:
-  FirstSeen LastSeen  Count From      SubobjectPath Type    Reason      Message
-  --------- --------  ----- ----      ------------- --------  ------      -------
-  6m    6m    1 {service-controller }     Normal    CreatingLoadBalancer  Creating load balancer
-  6m    6m    1 {service-controller }     Normal    CreatedLoadBalancer Created load balancer
+  FirstSeen	LastSeen	Count	From			SubobjectPath	Type		Reason			Message
+  ---------	--------	-----	----			-------------	--------	------			-------
+  3m		3m		1	{service-controller }			Normal		CreatingLoadBalancer	Creating load balancer
+  2m		2m		1	{service-controller }			Normal		CreatedLoadBalancer	Created load balancer
 ```
 
-After a few minutes, you should be able to view the kubernetes dashboard. In this example it is located at http://aa95470398b1711e6b3a706da4d1c1f9-1324035908.us-west-2.elb.amazonaws.com.
+After a few minutes, you should be able to view the kubernetes dashboard. In this example it is located at http://ae7a0bae03c1511e78f8f06148e55c0f-1296896684.us-west-2.elb.amazonaws.com.
 
 ### Debugging
 
@@ -401,22 +412,20 @@ In order to effect these changes, make appropriate adjustments to the configurat
 In other words:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/${CLUSTER}.yaml
 ```
-
-Replace `foo.yaml` with the name of the configuration file you intend to use.
 
 #### Upgrading Kubernetes Version of Master Nodes
 As mentioned above, before you can upgrade the Kubernetes version, you will first need to update your configuration file with the intended version and run:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/<your_config>.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./up.sh --config $HOME/.kraken/${CLUSTER}.yaml
 ```
 
 Then run:
 
  ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./upgrade.sh --config $HOME/.kraken/<your_config>.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./upgrade.sh --config $HOME/.kraken/${CLUSTER}.yaml
 ```
 
 Refer to [Kuberntes release versioning](https://github.com/kubernetes/kubernetes/blob/release-1.5.4/docs/design/versioning.md#supported-releases) for questions about supported versions
@@ -426,10 +435,8 @@ Refer to [Kuberntes release versioning](https://github.com/kubernetes/kubernetes
 How zen of you - everything must come to end, including Kubernetes clusters. To destroy a cluster created with K2, please do the following:
 
 ```bash
-docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./down.sh --config $HOME/.kraken/foo.yaml
+docker run $K2OPTS quay.io/samsung_cnct/k2:latest ./down.sh --config $HOME/.kraken/${CLUSTER}.yaml
 ```
-
-Replace `foo.yaml` with the name of the configuration file you intended to use
 
 # Docs
 Further information can be found here:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This will generate a config.yaml file located at
 ```
 ${KRAKEN}/config.yaml
 ```
+
 In this section, the variable `YOURCLUSTER` refers to the name you must assign to your cluster at the bottom of the generated `config.yaml` in the deployments section, which once a name has been decided would look like:
 
 ```
@@ -118,17 +119,29 @@ deployment:
     - name: YOURCLUSTER
 ```
 
-We suggest you rename the `config.yaml` file to something like
+Should should then rename the `config.yaml` file to `YOURCLUSTER.yaml`.  This is best practice.
 
-```
-YOURCLUSTER.yaml
-```
-
-**For the rest of the discussion, we will assume that the environmental variable `${CLUSTER}` has been set to the name of your cluster**
-
+**For the rest of the discussion, we will assume that the environmental variable `${CLUSTER}` has been set to the name of your cluster.**
 
 It is particularly useful when trying to create and manage multiple clusters, each of which
 **must** have unique names.
+
+## Configure your Kubernetes Cluster
+
+### Important configuration variables to adjust
+
+While all configuration options are available for a reason, some are more important than others.  Some key ones include
+
+- `clusters[x].providerConfig`
+- `clusters[x].nodePools[x].count`
+- `kubeConfig[x].version`
+- `kubeConfig[x].hyperkubeLocation`
+- `helmConfigs[x].charts`
+
+As well as the region and subnet selections under provider clauses.
+
+For a detailed explanation of all configuration variables, please consult [our configuration documentation](Documentation/kraken-configs/README.md)
+
 
 ### Preparing AWS credentials
 
@@ -159,7 +172,7 @@ This will take a while, and will generate a lot of output.
 
 ### kubectl
 
-After creating a cluster, to use the kubectl shipped with K2, run:
+After creating a cluster, to use the kubectl shipped with K2, run commands in the following fashion:
 
 ```bash
 docker run $K2OPTS quay.io/samsung_cnct/k2:latest kubectl --kubeconfig $HOME/.kraken/${CLUSTER}/admin.kubeconfig get nodes
@@ -229,23 +242,6 @@ Then the ssh hostnames available will be:
 - clusterNodes-1 through clusterNodes-3
 - specialNodes-1 through specialNodes-2
 
-## Configure your Kubernetes Cluster
-
-Earlier, you copied a sample cluster configuration over into `~/.kraken`.  Please take a moment to review the sample configuration and make changes if you desire
-
-### Important configuration variables to adjust
-
-While all configuration options are available for a reason, some are more important than others.  Some key ones include
-
-- `cluster`
-- `kubeConfig.version`
-- `kubeConfig.hyperkubeLocation`
-- `providerConfig.region`
-- `nodePools[x].count`
-- `nodePools[x].providerConfig.type`
-- `helmConfig.charts`
-
-For a detailed explanation of all configuration variables, please consult [our configuration documentation](Documentation/kraken-configs/README.md)
 
 ## Starting your own Kubernetes Cluster
 


### PR DESCRIPTION
Replaced YOURCLUSTER, foo, and <your_config> in example command lines with ${CLUSTER}.
Left YOURCLUSTER for examples inside the config file.
Updated helm output and usage, especially for search and install of kubernetes-dashboard.
Added instructions to bring the cluster up prior to the examples for accessing the cluster.