### PR TITLE
Change the tiller-install check to test more reliably

### DIFF
--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -94,7 +94,7 @@
 - name: Wait for tiller to be ready
   command: "{{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} --namespace=kube-system get deploy tiller-deploy -o json"
   register: output
-  until: (output | succeeded) and ((output.stdout | from_json).status.availableReplicas | default(0)) > 0
+  until: (output | succeeded) and "True" in ((output.stdout | from_json).status.conditions | map(attribute='status') | list )
   retries: 600
   delay: 1
   changed_when: false


### PR DESCRIPTION
For some reason the results show
```
    "status": {
        "conditions": [
            {
                "lastTransitionTime": "2017-05-22T16:57:39Z",
                "lastUpdateTime": "2017-05-22T16:57:39Z",
                "message": "Deployment has minimum availability.",
                "reason": "MinimumReplicasAvailable",
                "status": "True",
                "type": "Available"
            }
```
despite not having an entry for `availableReplicas`.

See if the status is actually correct.