### PR TITLE
fixed pathing of template in kraken.cluster_common

### DIFF
--- a/ansible/roles/kraken.cluster_common/tasks/main.yaml
+++ b/ansible/roles/kraken.cluster_common/tasks/main.yaml
@@ -11,5 +11,5 @@
 
 - name: Generate shell command help text
   template:
-    src: templates/help.txt.jinja2
+    src: help.txt.jinja2
     dest: "{{ config_base | expanduser }}/help.txt"


### PR DESCRIPTION
Was previously causing this error:
```TASK [roles/kraken.cluster_common : Generate shell command help text] **********
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to find 'templates/help.txt.jinja2' in expected paths."}
```
