### PR TITLE
removed redundant helm and made into one-liner for ease of cut and paste

### DIFF
--- a/ansible/roles/kraken.cluster_common/templates/help.txt.jinja2
+++ b/ansible/roles/kraken.cluster_common/templates/help.txt.jinja2
@@ -9,9 +9,7 @@ To use helm:
 ------------
 
 {% for cluster in kraken_config.clusters %}
-    KUBECONFIG={{ config_base }}/{{ cluster.name }}/admin.kubeconfig helm \
-      HELM_HOME={{ config_base }}/{{ cluster.name }}/.helm \
-      helm <helm command>
+    KUBECONFIG={{ config_base }}/{{ cluster.name }}/admin.kubeconfig HELM_HOME={{ config_base }}/{{ cluster.name }}/.helm helm <helm command>
 {% endfor %}
 
 To ssh:
@@ -23,4 +21,3 @@ To ssh:
 {%     endfor                            %}
 {%   endfor                              %}
 {% endfor                                %}
-


### PR DESCRIPTION
for terminal commands with k2, I need to edit this command and replace `root` with `$HOME`, which was difficult when the command was three lines long. I also removed an extra `helm` hiding in there