### PR TITLE
doing my part to remove the jinja2 templating warning.

### DIFF
--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -85,7 +85,7 @@
 - name: Do not allow multiple clusters in config
   fail:
     msg: "Multiple clusters are not yet supported in k2"
-  when: "{{ kraken_config.clusters | length | int > 1 }}"
+  when: kraken_config.clusters | length > 1 | int
 
 - name: Ensure each nodePool corresponds to exactly one of the node roles (i.e. etcd, master, or node)
   fail:

--- a/ansible/roles/kraken.rbac/tasks/build-access.yaml
+++ b/ansible/roles/kraken.rbac/tasks/build-access.yaml
@@ -32,7 +32,7 @@
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} get nodes --no-headers=true
   register: rbac_get_nodes_result
-  until: "{{ rbac_get_nodes_result.stdout_lines | length }} >= 1 | int"
+  until: rbac_get_nodes_result.stdout_lines | length >= 1 | int
   retries: "{{ repetitions | int }}"
   delay: "{{ rep_interval | int }}"
   when: "(not (dryrun | bool))"

--- a/ansible/roles/kraken.readiness/tasks/do-wait.yaml
+++ b/ansible/roles/kraken.readiness/tasks/do-wait.yaml
@@ -49,6 +49,6 @@
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} get nodes --no-headers=true
   register: job_get_nodes_result
-  until: "{{ job_get_nodes_result.stdout_lines | length }} >= needed_nodes | int"
+  until: job_get_nodes_result.stdout_lines | length >= needed_nodes | int
   retries: "{{ remaining_time | int }}"
   delay: "{{ wait_interval | int }}"


### PR DESCRIPTION
Example of warnings we dont want to keep seeing:

TASK [kraken.config : Do not allow multiple clusters in config] ***************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ kraken_config.clusters |
length | int > 1 }}

TASK [roles/kraken.rbac : Wait for api server response before continuing] *****************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{
rbac_get_nodes_result.stdout_lines | length }} >= 1 | int


TASK [roles/kraken.readiness : Get all nodes] *********************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{
job_get_nodes_result.stdout_lines | length }} >= needed_nodes | int
