### PR TITLE
Dryrun tags bug fixing

### DIFF
--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -107,7 +107,7 @@
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{ cluster.name }}/auth/rbac-canal-policy.yaml
   register: job_rbac_canal_results
-  when: 
+  when:
     - "cluster.kubeAuth.authz.rbac is defined"
     - "(not (dryrun | bool))"
 

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -64,11 +64,7 @@
     kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
     kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
     api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
-<<<<<<< HEAD
   when: "(not (dryrun | bool))"
-=======
-  when: "{{ not (config_dryrun | bool) }}"
->>>>>>> change name of variable for dryrun
 
 - name: check kube-networking namespace state
   command: >
@@ -123,8 +119,4 @@
 - name: Deploy canal daemonset
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{ cluster.name }}/fabric/canal.yaml --namespace=kube-networking
-<<<<<<< HEAD
   when: "(not (dryrun | bool))"
-=======
-  when: "{{ not (config_dryrun | bool) }}"
->>>>>>> change name of variable for dryrun

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -54,16 +54,19 @@
       - "{{ kubernetes_minor_versions[ cluster.name ] }}/config.yaml.part.jinja2"
       - config.yaml.part.jinja2
 
+- name: set api_servers for checking 'api server'
+  set_fact:
+    kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
+    kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
+    api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
+  when: not ( dryrun | bool )
+
 - name: Wait for api server
   wait_for:
     host: "{{ item | regex_replace('https://','') }}"
     port: 443
     timeout: 600
   with_items: "{{ api_servers }}"
-  vars:
-    kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
-    kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
-    api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
   when: not ( dryrun | bool )
 
 - name: check kube-networking namespace state

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -64,7 +64,7 @@
     kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
     kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
     api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
-  when: "(not (dryrun | bool))"
+  when: not ( dryrun | bool )
 
 - name: check kube-networking namespace state
   command: >
@@ -72,7 +72,7 @@
   ignore_errors: yes
   changed_when: false
   register: kube_networking_namespace
-  when: "(not (dryrun | bool))"
+  when: not ( dryrun | bool )
   failed_when: false
 
 - name: Ensure the kube-networking namespace exists
@@ -83,7 +83,7 @@
   until: result|succeeded
   delay: 1
   when:
-    - "(not (dryrun | bool))"
+    - not ( dryrun | bool )
     - "'Error' in kube_networking_namespace.stderr "
   ignore_errors: yes
 
@@ -93,14 +93,14 @@
   ignore_errors: yes
   changed_when: false
   register: kube_networking_namespace
-  when: "(not (dryrun | bool))"
+  when: not ( dryrun | bool )
   failed_when: false
 
 - name: Confirm kube-networking namespace created
   fail:
     msg: "kube-networking namespace creation failed"
   when:
-    - "(not (dryrun | bool))"
+    - not ( dryrun | bool )
     - "'Error' in kube_networking_namespace.stderr "
 
 - name: Deploy canal RBAC policy
@@ -109,14 +109,14 @@
   register: job_rbac_canal_results
   when:
     - "cluster.kubeAuth.authz.rbac is defined"
-    - "(not (dryrun | bool))"
+    - not ( dryrun | bool )
 
 - name: Deploy canal configuration
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{ cluster.name }}/fabric/config.yaml --namespace=kube-networking
-  when: "(not (dryrun | bool))"
+  when: not ( dryrun | bool )
 
 - name: Deploy canal daemonset
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{ cluster.name }}/fabric/canal.yaml --namespace=kube-networking
-  when: "(not (dryrun | bool))"
+  when: not ( dryrun | bool )

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -54,19 +54,16 @@
       - "{{ kubernetes_minor_versions[ cluster.name ] }}/config.yaml.part.jinja2"
       - config.yaml.part.jinja2
 
-- name: set api_servers for checking 'api server'
-  set_fact:
-    kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
-    kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
-    api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
-  when: not ( dryrun | bool )
-
 - name: Wait for api server
   wait_for:
     host: "{{ item | regex_replace('https://','') }}"
     port: 443
     timeout: 600
   with_items: "{{ api_servers }}"
+  vars:
+    kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
+    kubeconfigfile: "{{ ( kubefn | is_file ) | ternary( kubefn, '/dev/null' ) }}"
+    api_servers: "{{ lookup('file', kubeconfigfile) | from_yaml | json_query('clusters[*].cluster.server') }}"
   when: not ( dryrun | bool )
 
 - name: check kube-networking namespace state

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
@@ -64,7 +64,11 @@
     kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
     kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
     api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
+<<<<<<< HEAD
   when: "(not (dryrun | bool))"
+=======
+  when: "{{ not (config_dryrun | bool) }}"
+>>>>>>> change name of variable for dryrun
 
 - name: check kube-networking namespace state
   command: >
@@ -119,4 +123,8 @@
 - name: Deploy canal daemonset
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} apply -f {{ config_base | expanduser }}/{{ cluster.name }}/fabric/canal.yaml --namespace=kube-networking
+<<<<<<< HEAD
   when: "(not (dryrun | bool))"
+=======
+  when: "{{ not (config_dryrun | bool) }}"
+>>>>>>> change name of variable for dryrun

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
@@ -11,4 +11,4 @@
   when: kraken_action == 'up'
 - include: aws-template.yaml
 - include: aws-action.yaml
-  when: "{{ not (dryrun | bool) }}"
+  when: not ( dryrun | bool )

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
@@ -4,11 +4,11 @@
     cluster: "{{ a_cluster }}"
 
 - name: Set ssl_cert_common_name
-  set_fact: 
+  set_fact:
     ssl_cert_common_name: "*.{{ cluster.providerConfig.region }}.elb.amazonaws.com"
-
 
 - include: aws-certs.yaml
   when: kraken_action == 'up'
 - include: aws-template.yaml
 - include: aws-action.yaml
+  when: "{{ not (dryrun | bool) }}"

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
@@ -3,10 +3,6 @@
   set_fact:
     default_kube_basic_auth: "{{ cluster.kubeAuth.authn.basic | selectattr('user', 'match', '^'+cluster.kubeAuth.authn.default_basic_user+'$') | first }}"
 
-- name: Render a deployment manager template
-  template: src=deploymentmanager-create.yaml.jinja2
-   dest="{{ config_base | expanduser }}/{{ cluster.name }}/deploymentmanager-create.yaml"
-
 - name: Deploy cluster
   command: >
     gcloud deployment-manager deployments create {{ cluster.name }}-k2-deployment

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
@@ -1,8 +1,4 @@
 ---
-- name: Retrive default auth from kube basic authn list
-  set_fact:
-    default_kube_basic_auth: "{{ cluster.kubeAuth.authn.basic | selectattr('user', 'match', '^'+cluster.kubeAuth.authn.default_basic_user+'$') | first }}"
-
 - name: Deploy cluster
   command: >
     gcloud deployment-manager deployments create {{ cluster.name }}-k2-deployment

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
@@ -7,7 +7,11 @@
   file:
     path: "{{ config_base | expanduser }}/{{ cluster.name }}"
     state: directory
-    
+
+- name: Retrive default auth from kube basic authn list
+  set_fact:
+    default_kube_basic_auth: "{{ cluster.kubeAuth.authn.basic | selectattr('user', 'match', '^'+cluster.kubeAuth.authn.default_basic_user+'$') | first }}"
+
 - name: Render a deployment manager template for created-cluster.yaml in advance
   template: src=deploymentmanager-create.yaml.jinja2
    dest="{{ config_base | expanduser }}/{{ cluster.name }}/deploymentmanager-create.yaml"

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
@@ -15,11 +15,7 @@
 - include: authenticate.yaml
   when: not ( dryrun | bool )
 - include: process-cluster.yaml
-<<<<<<< HEAD
-  when: (kraken_action == 'up')
-=======
   when: kraken_action == 'up' and not ( dryrun | bool )
->>>>>>> fixing confict for #501
 - include: destroy-cluster.yaml
   when: kraken_action == 'down' and not ( dryrun | bool )
 - include: deauthenticate.yaml

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
@@ -8,9 +8,19 @@
     path: "{{ config_base | expanduser }}/{{ cluster.name }}"
     state: directory
 
+- name: Render a deployment manager template for created-cluster.yaml in advance
+  template: src=deploymentmanager-create.yaml.jinja2
+   dest="{{ config_base | expanduser }}/{{ cluster.name }}/deploymentmanager-create.yaml"
+
 - include: authenticate.yaml
+  when: not ( dryrun | bool )
 - include: process-cluster.yaml
+<<<<<<< HEAD
   when: (kraken_action == 'up')
+=======
+  when: kraken_action == 'up' and not ( dryrun | bool )
+>>>>>>> fixing confict for #501
 - include: destroy-cluster.yaml
-  when: kraken_action == 'down'
+  when: kraken_action == 'down' and not ( dryrun | bool )
 - include: deauthenticate.yaml
+  when: not ( dryrun | bool )

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
@@ -8,10 +8,6 @@
     path: "{{ config_base | expanduser }}/{{ cluster.name }}"
     state: directory
 
-- name: Render a deployment manager template for created-cluster.yaml in advance
-  template: src=deploymentmanager-create.yaml.jinja2
-   dest="{{ config_base | expanduser }}/{{ cluster.name }}/deploymentmanager-create.yaml"
-
 - include: authenticate.yaml
   when: not ( dryrun | bool )
 - include: process-cluster.yaml

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
@@ -7,6 +7,10 @@
   file:
     path: "{{ config_base | expanduser }}/{{ cluster.name }}"
     state: directory
+    
+- name: Render a deployment manager template for created-cluster.yaml in advance
+  template: src=deploymentmanager-create.yaml.jinja2
+   dest="{{ config_base | expanduser }}/{{ cluster.name }}/deploymentmanager-create.yaml"
 
 - include: authenticate.yaml
   when: not ( dryrun | bool )

--- a/ansible/roles/kraken.ssh/kraken.ssh.selector/tasks/main.yaml
+++ b/ansible/roles/kraken.ssh/kraken.ssh.selector/tasks/main.yaml
@@ -15,7 +15,7 @@
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: a_cluster.providerConfig.provider == 'gke'
+  when: a_cluster.providerConfig.provider == 'gke' and not ( dryrun | bool )
 
 - name: Error Provider
   include_role:


### PR DESCRIPTION
k2/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml

```
- name: Wait for api server
 wait_for:
   host: "{{ item | regex_replace('https://','') }}"
   port: 443
   timeout: 600
 with_items: "{{ api_servers }}"
 vars:
   kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
   kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
   api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
 when: not ( dryrun | bool )
```
error log

```
fatal: [localhost]: FAILED! => {"failed": true, "msg": "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}: An unhandled exception occurred while running the lookup plugin 'file'. Error was a <class 'ansible.errors.AnsibleError'>, original message: could not locate file in lookup: /Users/blackdog/.kraken/cappuccino/admin.kubeconfig"}
```

**A task that includes 'vars' get evaluated even if conditonal exists for the task.**

```
Note that if you have several tasks that all share the same conditional statement, you can affix the conditional to a task include statement as below. All the tasks get evaluated, but the conditional is applied to each and every task:
```


I added conditional in #501 for terraform module in file below 
k2/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
```
...
- include: aws-action.yaml
  when: not ( dryrun | bool )
...
```

k2/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-action.yaml

Is supposed to set 'kraken_endpoint', Because it's not executed in case of using 'dryrun' tag.
```
...
- name: Set the kraken end point fact
  set_fact:
    kraken_endpoint: "{{ endpoint_result.stdout }}"
  when: endpoint_result | succeeded and not endpoint_result | skipped
...
```

So that "kraken_endpoint" is not defined because of not running terraform modules in aws-action.yaml

k2/ansible/roles/kraken.access/tasks/setup-certs.yaml

```
...
- include: generate-admin-kubeconfig.yaml
  when: kraken_endpoint is defined
...
```
Then generate-admin-kubeconfig.yaml doesn't generate admun.kubeconfig file.

k2/ansible/roles/kraken.fabric/kraken.fabric.flannel/tasks/main.yaml
```
- name: Wait for api server
  wait_for:
    host: "{{ item | regex_replace('https://','') }}"
    port: 443
    timeout: 600
  with_items: "{{ api_servers }}"
  vars:
    kubefn: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
    kubeconfig: "{{ kubefn | is_file | ternary( kubefn, '/dev/null' ) }}"
    api_servers: "{{ lookup('file', kubeconfig) | from_yaml | json_query('clusters[*].cluster.server') }}"
  when: not ( dryrun | bool )
```

It occurs error due to admin.kubeconfig doesn't exist on dryrun.



 