### PR TITLE
made 1.6.4 default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ podTemplate(label: 'k2', containers: [
 
             stage('checkout') {
                 checkout scm
-            }    
+            }
 
             stage('fetch credentials') {
                 sh 'build-scripts/fetch-credentials.sh'
@@ -51,14 +51,14 @@ podTemplate(label: 'k2', containers: [
 
                         container('e2e-tester') {
                             stage('run e2e tests') {
-                                sh "PWD=`pwd` && build-scripts/conformance-tests.sh v1.5.6 ${env.JOB_BASE_NAME}-${env.BUILD_ID} /mnt/scratch"
+                                sh "PWD=`pwd` && build-scripts/conformance-tests.sh v1.6.4 ${env.JOB_BASE_NAME}-${env.BUILD_ID} /mnt/scratch"
                             }
                         }
                     } finally {
                         container('k2-tools') {
                             stage('destroy k2 cluster') {
-                                sh 'PWD=`pwd` && ./down.sh --config $PWD/cluster/aws/config.yaml --output $PWD/cluster/aws/ || true'                        
-                                junit "output/artifacts/*.xml"                                
+                                sh 'PWD=`pwd` && ./down.sh --config $PWD/cluster/aws/config.yaml --output $PWD/cluster/aws/ || true'
+                                junit "output/artifacts/*.xml"
                             }
                         }
                     }
@@ -104,6 +104,6 @@ podTemplate(label: 'k2', containers: [
             }
         }
     }
-  }  
+  }
 
 // vi: ft=groovy

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -25,10 +25,6 @@ definitions:
           chart: heapster
           version: 0.1.0
           namespace: kube-system
-        - name: central-logging
-          repo: atlas
-          chart: central-logging
-          version: 0.2.0
   fabricConfigs:
     - &defaultCanalFabric
       name: defaultCanalFabric
@@ -120,7 +116,7 @@ definitions:
     - &defaultKube
       name: defaultKube
       kind: kubernetes
-      version: v1.5.6
+      version: v1.6.4
       hyperkubeLocation: gcr.io/google_containers/hyperkube
   containerConfigs:
     - &defaultDocker
@@ -372,7 +368,7 @@ definitions:
             user: "admin"
         default_basic_user: "admin"
    - &rbacKubeAuth
-      authz: 
+      authz:
         rbac:
           # super_user is required until kubernetes 1.5 is no longer supported by k2.
           # It is not used by kubernetes 1.6 or later.
@@ -432,7 +428,7 @@ deployment:
           nodeConfig: *defaultAwsSpecialNode
           keyPair: *defaultKeyPair
       fabricConfig: *kubeVersionedFabric
-      kubeAuth: *defaultKubeAuth
+      kubeAuth: *rbacKubeAuth
       helmConfig: *defaultHelm
       dnsConfig: *defaultDns
       helmOverride:

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -19,11 +19,7 @@ definitions:
           url: http://atlas.cnct.io
         - name: stable
           url: https://kubernetes-charts.storage.googleapis.com
-      charts:
-        - name: central-logging
-          repo: atlas
-          chart: central-logging
-          version: 0.2.0
+      charts: []
   fabricConfigs:
     - &defaultCanalFabric
       name: defaultCanalFabric
@@ -87,7 +83,7 @@ definitions:
     - &defaultKube
       name: defaultKube
       kind: kubernetes
-      version: v1.5.6
+      version: v1.6.4
       hyperkubeLocation: gcr.io/google_containers/hyperkube
   containerConfigs:
     - &defaultDocker
@@ -170,7 +166,7 @@ deployment:
       dns: 10.32.0.2
       domain: cluster.local
       providerConfig: *defaultGKE
-      kubeAuth: *defaultKubeAuth
+      kubeAuth: *rbacKubeAuth
       nodePools:
         - name: clusternodes
           count: 2


### PR DESCRIPTION
this makes 1.6.4 the default version of kubernetes.  Temporarily we are removing the central logging chart because we have not yet written the rbac specs for fluentd. This will be covered in the 0.3 milestone, and then it can be added back in. 