### PR TITLE
Bumping default version of weave-net to latest: 1.9.8. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ generated/
 .kraken/
 .rnd
 .srl
+.pyc
 .terraform.d/
 clusters/
 ansible/cluster_changes.txt

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -91,11 +91,14 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-npc
+        network:
+          network: 10.128.0.0/10
+          nodeConnectionLimit: 30
     - &defaultWeaveFabric16
       name: defaultWeaveFabric16
       kind: fabric
@@ -103,11 +106,14 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-npc
+        network:
+          network: 10.128.0.0/10
+          nodeConnectionLimit: 30
     - &kubeVersionedWeaveFabric
       name: kubeVersionedWeaveFabric
       kind: versionedFabric

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -86,11 +86,14 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-npc
+        network:
+          network: 10.128.0.0/10
+          nodeConnectionLimit: 30
     - &defaultWeaveFabric16
       name: defaultWeaveFabric16
       kind: fabric
@@ -98,11 +101,14 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.7
+            version: 1.9.8
             location: weaveworks/weave-npc
+        network:
+          network: 10.128.0.0/10
+          nodeConnectionLimit: 30
     - &kubeVersionedWeaveFabric
       name: kubeVersionedWeaveFabric
       kind: versionedFabric

--- a/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
@@ -6,6 +6,9 @@
 #
 # This manifest installs weave-net cni on kubernetes clusters v1.5 and earlier.
 #
+# Further details about configuring and environment variables found here:
+# https://www.weave.works/docs/net/latest/kube-addon/
+#
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -68,6 +71,11 @@ spec:
           image: {{fabricConfigVal.options.containers.weave.location}}:{{fabricConfigVal.options.containers.weave.version}}
           command:
             - /home/weave/launch.sh
+          env:
+            - name: IPALLOC_RANGE
+              value: {{fabricConfigVal.options.network.network}}
+            - name: CONN_LIMIT
+              value: {{fabricConfigVal.options.network.nodeConnectionLimit}}
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/weave.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/weave.yaml.part.jinja2
@@ -5,8 +5,11 @@
 #--------------------------
 #
 # This manifest installs weave-net cni on kubernetes clusters v1.5 and earlier.
-#
 
+#
+# Further details about configuring and environment variables found here:
+# https://www.weave.works/docs/net/latest/kube-addon/
+#
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -34,6 +37,11 @@ spec:
           image: {{fabricConfigVal.options.containers.weave.location}}:{{fabricConfigVal.options.containers.weave.version}}
           command:
             - /home/weave/launch.sh
+          env:
+          - name: IPALLOC_RANGE
+            value: {{fabricConfigVal.options.network.network}}
+          - name: CONN_LIMIT
+            value: {{fabricConfigVal.options.network.nodeConnectionLimit}}
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/schemas/config/v1/weaveFabricNetwork.json
+++ b/schemas/config/v1/weaveFabricNetwork.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/weaveFabricNetwork.json",
+  "title": "Weave Fabric Network configuration",
+  "description": "Describes the configuration of a Weave network fabric.",
+
+  "properties": {
+    "network": {
+      "description": "Network CIDR for pods in the fabric",
+      "format": "cidr",
+      "type": "string"
+    },
+    "nodeConnectionLimit": {
+      "description": "Maximum number of connection made per node. A cluster size of N would have each node making (N-1) connections",
+      "type": "number"
+    }
+  },
+
+  "required": [
+    "network",
+    "nodeConnectionLimit"
+  ],
+
+  "type": "object"
+}

--- a/schemas/config/v1/weaveFabricOptions.json
+++ b/schemas/config/v1/weaveFabricOptions.json
@@ -4,11 +4,13 @@
 
   "description": "Weave Fabric Options configuration",
   "properties": {
-    "containers": { "$ref": "weaveFabricContainers.json" }
+    "containers": { "$ref": "weaveFabricContainers.json" },
+    "network": { "$ref": "weaveFabricNetwork.json" }
   },
 
   "required": [
-    "containers"
+    "containers",
+    "network"
   ],
 
   "type": "object"


### PR DESCRIPTION
Default version of weave-net seems to have an issue of resolving dns names within pods. Issue seems to be fixed on version 1.9.8, bumping defaults to that version.