### PR TITLE
deleted tags from update actions

### DIFF
--- a/ansible/update.yaml
+++ b/ansible/update.yaml
@@ -7,5 +7,4 @@
   roles:
     - {
         role: '{{ playbook_dir }}/roles/kraken.update/kraken.update.selector',
-        tags: [ 'provider', 'ssh', 'readiness', 'services', 'all', 'provider_only']
       }

--- a/update.sh
+++ b/update.sh
@@ -18,6 +18,6 @@ source "${my_dir}/lib/common.sh"
 # setup a sigint trap
 trap control_c SIGINT
 
-DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" --tags "${KRAKEN_TAGS}" || show_update_error
+DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" || show_update_error
 
 show_update


### PR DESCRIPTION
Update action does not need tags for now, so references to them were removed. 

This is part of [K2cli issue](https://github.com/samsung-cnct/k2cli/issues/70).