### PR TITLE
allow a user to specify a pre-existing VPC for aws clusters

### DIFF
--- a/Documentation/kraken-configs/provider/aws.md
+++ b/Documentation/kraken-configs/provider/aws.md
@@ -28,7 +28,8 @@
 | default_security_group_id | __Required__ | String | id of the default security group for the linked VPC |
 
 It is important to note that K2 will not auto-detect any existing networking infrastructure in the VPC.  K2 assumes
-that you have configured things correctly and will throw an error on a resource conflict.
+that you have configured things correctly and will throw an error on a resource conflict.  The listed route_table_id
+must have a valid route to an internet gateway.  K2 has each node pull images from public repositories.  
 
 ## subnets options
 | Key Name | Required     | Type   | Description|

--- a/Documentation/kraken-configs/provider/aws.md
+++ b/Documentation/kraken-configs/provider/aws.md
@@ -10,6 +10,7 @@
 | type            | Optional     | String        | Type of provider. cloudinit or autonomous. Autonomous providers do not require cloud init configuration. Defaults to cloudinit |
 | resourcePrefix  | Optional     | String        | String prefix to use for AWS resource naming |
 | vpc             | __Required__ | String        | VPC CIDR block |
+| existing_vpc    | Optional     | Object Array  | pre-existing VPC to land cluster in |
 | region          | __Required__ | String        | region you want your cluster to be created in.  Currently we only support one AWS region per cluster |
 | subnet          | __Required__ | Object Array  | Subnet describes the AWS subnets to be created per AZ |
 | egressAcl       | __Required__ | Object Array  | Array of VPC egresses |
@@ -18,6 +19,16 @@
 | ingressSecurity | __Required__ | Object Array  | Array of Security group ingresses |
 | egressSecurity  | __Required__ | Object Array  | Array of Secuirty group egresses |
 | cert            | Optional     | Object        | Loadbalancer certificates info |
+
+## existing_vpc
+| Key Name | Required     | Type   | Description|
+| -------- | ------------ | ------ | --- |
+| id       | __Required__ | String | id of an existing VPC from the AWS console |
+| route_table_id | __Required__ | String | id of a route table in the linked VPC |
+| default_security_group_id | __Required__ | String | id of the default security group for the linked VPC |
+
+It is important to note that K2 will not auto-detect any existing networking infrastructure in the VPC.  K2 assumes
+that you have configured things correctly and will throw an error on a resource conflict.
 
 ## subnets options
 | Key Name | Required     | Type   | Description|

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-template.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/aws-template.yaml
@@ -10,6 +10,7 @@
     state: directory
   with_items:
     - vpc
+    - route53
     - keypair
     - subnet
     - cluster_secgroup
@@ -26,6 +27,7 @@
             dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.dest }}/module.tf"
   with_items:
     - { source: kraken.provider.aws.module.vpc.tf.jinja2, dest: vpc }
+    - { source: kraken.provider.aws.module.route53.tf.jinja2, dest: route53 }
     - { source: kraken.provider.aws.module.keypair.tf.jinja2, dest: keypair }
     - { source: kraken.provider.aws.module.subnet.tf.jinja2, dest: subnet }
     - { source: kraken.provider.aws.module.cluster_secgroup.tf.jinja2, dest: cluster_secgroup }

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.route53.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.route53.tf.jinja2
@@ -1,0 +1,14 @@
+variable "vpc_name" {}
+variable "vpc_id" {}
+
+# A VPC-only route53 zone and record
+resource "aws_route53_zone" "private_zone" {
+  name          = "${var.vpc_name}.internal"
+  comment       = "A VPC-only zone for ${var.vpc_name} kubernetes cluster"
+  vpc_id        = "${var.vpc_id}"
+  force_destroy = true
+}
+
+output "route53_zone_id" {
+  value = "${aws_route53_zone.private_zone.zone_id}"
+}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
@@ -1,3 +1,5 @@
+{% if cluster.providerConfig.existing_vpc is not defined %}
+
 # AWS VPC block
 variable "cidr_block" {}
 variable "vpc_name" {}
@@ -24,14 +26,6 @@ resource "aws_vpc" "vpc" {
     Name = "${var.vpc_name}_vpc",
     KubernetesCluster = "${var.vpc_name}"
   }
-}
-
-# A VPC-only route53 zone and record
-resource "aws_route53_zone" "private_zone" {
-  name          = "${var.vpc_name}.internal"
-  comment       = "A VPC-only zone for ${var.vpc_name} kubernetes cluster"
-  vpc_id        = "${aws_vpc.vpc.id}"
-  force_destroy = true
 }
 
 # DHCP options sets
@@ -114,6 +108,20 @@ output "default_security_group_id" {
   value = "${aws_vpc.vpc.default_security_group_id}"
 }
 
-output "route53_zone_id" {
-  value = "${aws_route53_zone.private_zone.zone_id}"
+{% else %}
+variable "cidr_block" {}
+variable "vpc_name" {}
+
+output "id" {
+  value = "{{cluster.providerConfig.existing_vpc.id}}"
 }
+
+output "route_table_id" {
+  value = "{{cluster.providerConfig.existing_vpc.route_table_id}}"
+}
+
+output "default_security_group_id" {
+  value = "{{cluster.providerConfig.existing_vpc.default_security_group_id}}"
+}
+
+{% endif %}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.tf.jinja2
@@ -14,6 +14,14 @@ module "vpc" {
   vpc_name  = "{{cluster.name}}"
 }
 
+module "route53" {
+  source = "./route53"
+
+  vpc_id = "${module.vpc.id}"
+  vpc_name  = "{{cluster.name}}"
+}
+
+
 module "keypair" {
   source = "./keypair"
 
@@ -42,7 +50,7 @@ module "etcd" {
   vpc_id = "${module.vpc.id}"
   etcds_name  = "{{cluster.name}}"
   cidr_block = "{{cluster.providerConfig.vpc}}"
-  route53_zone_id = "${module.vpc.route53_zone_id}"
+  route53_zone_id = "${module.route53.route53_zone_id}"
 {% for node in cluster.nodePools %}
 {% if node.etcdConfig is defined %}
   {{node.keyPair.name}}_{{node.name}}_key = "${module.keypair.{{node.keyPair.name}}_keyname}"
@@ -74,7 +82,7 @@ module "master" {
 {% endfor %}
 {% endif %}
 {% endfor %}
-  route53_zone_id = "${module.vpc.route53_zone_id}"
+  route53_zone_id = "${module.route53.route53_zone_id}"
   kubernetes_sec_group = "${module.cluster_secgroup.id}"
 }
 
@@ -107,5 +115,5 @@ output "kraken_endpoint" {
 }
 
 output "kraken_private_zone_id" {
-  value = "${module.vpc.route53_zone_id}"
+  value = "${module.route53.route53_zone_id}"
 }

--- a/schemas/config/v1/awsProviderConfig.json
+++ b/schemas/config/v1/awsProviderConfig.json
@@ -29,12 +29,13 @@
       "description": "Any prefix that should be prepended to resources in AWS to make them easier to identify.",
       "type": [ "string", "null" ]
     },
-    "vpc": {
+    "vpc": { 
       "description": "CIDR for the VPC for the cluster.",
       "format": "cidr",
       "type": "string",
       "default": "10.0.0.0/16"
     },
+    "existing_vpc": { "$ref": "awsVpcConfig.json" },
     "region": {
       "description": "Region to create resources in (us-east-1, us-west-2, etc.).",
       "type": "string",

--- a/schemas/config/v1/awsVpcConfig.json
+++ b/schemas/config/v1/awsVpcConfig.json
@@ -19,6 +19,7 @@
       "type": "string"
     }
   },
+  
   "required": [
     "id",
     "route_table_id",

--- a/schemas/config/v1/awsVpcConfig.json
+++ b/schemas/config/v1/awsVpcConfig.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/awsVpcConfig.json",
+  "$$target": "awsVpcConfig.json",
+  "title": "AWS VPC Configuration",
+  "description": "Describes an existing AWS VPC configuration to install a Kubernetes cluster into.",
+
+  "properties": {
+    "id": {
+      "description": "id of a pre-created VPC",
+      "type": "string"
+    },
+    "route_table_id": {
+      "description": "id of a pre-created route table that exists in the provided vpc.id",
+      "type": "string"
+    },
+    "default_security_group_id": {
+      "description": "id of the pre-created default security group for the provided vpc.id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "route_table_id",
+    "default_security_group_id"
+  ],
+
+  "type": "object"
+}


### PR DESCRIPTION
to use a pre-existing VPC a user will need to specify the vpc id,
a route table in that vpc and the id of the default security
group of the vpc.  the user should also be certain they have set
up all of the network CIDRs correctly as K2 will not help with
that.

this closes #124 