### PR TITLE
make subnet part of pre-existing VPC config

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.subnet.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.subnet.tf.jinja2
@@ -3,6 +3,7 @@ variable "vpc_id" {}
 variable "subnets_name" {}
 variable "route_table_id" {}
 
+{% if cluster.providerConfig.existing_vpc is not defined %}
 
 {% for subnet in cluster.providerConfig.subnet %}
 resource "aws_subnet" "vpc_subnet_{{subnet.name}}" {
@@ -28,3 +29,13 @@ output "{{subnet.name}}_subnet_id" {
   value = "${aws_subnet.vpc_subnet_{{subnet.name}}.id}"
 }
 {% endfor %}
+
+{% else %}
+
+{% for subnet in cluster.providerConfig.existing_vpc.subnet %}
+output "{{subnet.name}}_subnet_id" {
+  value = "{{subnet.id}}"
+}
+{% endfor %}
+
+{% endif %}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
@@ -1,8 +1,9 @@
-{% if cluster.providerConfig.existing_vpc is not defined %}
-
 # AWS VPC block
 variable "cidr_block" {}
 variable "vpc_name" {}
+
+{% if cluster.providerConfig.existing_vpc is not defined %}
+
 variable "dns_suffix" {
   type = "map"
   default = {
@@ -109,15 +110,12 @@ output "default_security_group_id" {
 }
 
 {% else %}
-variable "cidr_block" {}
-variable "vpc_name" {}
-
 output "id" {
   value = "{{cluster.providerConfig.existing_vpc.id}}"
 }
 
 output "route_table_id" {
-  value = "{{cluster.providerConfig.existing_vpc.route_table_id}}"
+  value = "ThisShouldnotBeUsed"
 }
 
 output "default_security_group_id" {

--- a/schemas/config/v1/awsPreexistingSubnetConfig.json
+++ b/schemas/config/v1/awsPreexistingSubnetConfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/awsPreexistingSubnetConfig.json",
+  "$$target": "awsPreexistingSubnetConfig",
+  "title": "AWS Subnet Identification",
+  "description": "Identifies an [AWS subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html) that is not managed by K2.",
+
+  "properties": {
+    "name": {
+      "description": "The name of the subnet, for use within k2 configurations.",
+      "type": "string"
+    },
+    "id": {
+      "description": "AWS id of the pre-existing subnet.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "id"
+  ],
+  "type": "object"
+}

--- a/schemas/config/v1/awsProviderConfig.json
+++ b/schemas/config/v1/awsProviderConfig.json
@@ -42,7 +42,7 @@
       "default": "us-east-1"
     },
     "subnet": {
-      "description": "List of subnets to use within a region for the cluster.",
+      "description": "List of subnets to use within a region for the cluster.  Should be omitted and will be ignored if existing_vpc hash is specified.",
       "items": { "$ref": "awsSubnetConfig.json" },
       "minItems": 1,
       "type": "array"
@@ -82,7 +82,6 @@
     "resourcePrefix",
     "vpc",
     "region",
-    "subnet",
     "egressAcl",
     "ingressAcl",
     "egressSecurity",

--- a/schemas/config/v1/awsVpcConfig.json
+++ b/schemas/config/v1/awsVpcConfig.json
@@ -11,18 +11,24 @@
       "type": "string"
     },
     "route_table_id": {
-      "description": "id of a pre-created route table that exists in the provided vpc.id",
+      "description": "DEPRECATED: id of a pre-created route table that exists in the provided vpc.id",
       "type": "string"
     },
     "default_security_group_id": {
       "description": "id of the pre-created default security group for the provided vpc.id",
       "type": "string"
+    },
+    "subnet": {
+      "description": "list of subnet ids that are part of the provided vpc.id",
+      "items": { "$ref": "awsPreexistingSubnetConfig.json" },
+      "minItems": 1,
+      "type": "array"
     }
   },
   
   "required": [
     "id",
-    "route_table_id",
+    "subnet",
     "default_security_group_id"
   ],
 


### PR DESCRIPTION
force user to supply subnet when BYOing a VPC.  

set other subnet option to be optional (don't need both)
set route_table_id as optional and set description to be DEPRECATED.

this closes #583 