### PR TITLE
taints and tolerations added for master nodepool

### DIFF
--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/v1.6/canal.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/v1.6/canal.yaml.part.jinja2
@@ -1,7 +1,7 @@
 ---
 #--------------------------
 # SOURCE OF THIS FILE: https://github.com/projectcalico/canal/blob/master/k8s-install/1.6/canal.yaml
-# 5/19/2017 mikeln - for samsung-cnct 
+# 5/19/2017 mikeln - for samsung-cnct
 #--------------------------
 # This manifest installs the calico/node container, as well
 # as the Calico CNI plugins and network config on
@@ -35,6 +35,10 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: "CriticalAddonsOnly"
           operator: "Exists"
+        - key: dedicatedMaster
+          operator: Equal
+          value: masters
+          effect: NoSchedule
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/v1.6/canal.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/v1.6/canal.yaml.part.jinja2
@@ -39,6 +39,7 @@ spec:
           operator: Equal
           value: masters
           effect: NoSchedule
+        - operator: Exists
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/v1.6/canal.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.flannel/templates/v1.6/canal.yaml.part.jinja2
@@ -35,9 +35,8 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: "CriticalAddonsOnly"
           operator: "Exists"
-        - key: dedicatedMaster
+        - key: node-role.kubernetes.io/master
           operator: Equal
-          value: masters
           effect: NoSchedule
         - operator: Exists
       containers:

--- a/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
@@ -117,6 +117,10 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: dedicatedMaster
+        operator: Equal
+        value: masters
+        effect: NoSchedule
       serviceAccountName: weave-net
       securityContext:
         seLinuxOptions: {}

--- a/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
@@ -116,10 +116,7 @@ spec:
       restartPolicy: Always
       tolerations:
       - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: dedicatedMaster
         operator: Equal
-        value: masters
         effect: NoSchedule
       - operator: Exists
       serviceAccountName: weave-net

--- a/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
+++ b/ansible/roles/kraken.fabric/kraken.fabric.weave/templates/v1.6/weave.yaml.part.jinja2
@@ -121,6 +121,7 @@ spec:
         operator: Equal
         value: masters
         effect: NoSchedule
+      - operator: Exists
       serviceAccountName: weave-net
       securityContext:
         seLinuxOptions: {}

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -77,7 +77,6 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
   tolerations:
-  - key: dedicatedMaster
+  - key: node-role.kubernetes.io/master
     operator: Equal
-    value: masters
     effect: NoSchedule

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -76,3 +76,8 @@ spec:
   - hostPath:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
+  tolerations:
+  - key: dedicatedMaster
+    operator: Equal
+    value: masters
+    effect: NoSchedule

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/controller-manager-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/controller-manager-manifest.yaml.jinja2
@@ -47,3 +47,8 @@ spec:
   - hostPath:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
+  tolerations:
+  - key: dedicatedMaster
+    operator: Equal
+    value: masters
+    effect: NoSchedule

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/controller-manager-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/controller-manager-manifest.yaml.jinja2
@@ -48,7 +48,6 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
   tolerations:
-  - key: dedicatedMaster
+  - key: node-role.kubernetes.io/master
     operator: Equal
-    value: masters
     effect: NoSchedule

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/kube-proxy-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/kube-proxy-manifest.yaml.jinja2
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+  - name: kube-proxy
+    image: {{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }}
+    command:
+    - /hyperkube
+    - proxy
+    - --master=http://127.0.0.1:8080
+    - --proxy-mode=iptables
+    - --v=7
+    - --logtostderr=true
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /etc/ssl/certs
+      name: ssl-certs-host
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /usr/share/ca-certificates
+    name: ssl-certs-host
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Equal
+    effect: NoSchedule

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
@@ -38,7 +38,7 @@
       docker://{{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }} \
       --exec=/hyperkube -- kubelet \
       --api_servers=http://127.0.0.1:8080 \
-      --register-schedulable=false \
+      --register-with-taints=dedicatedMaster=masters:NoSchedule \
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
@@ -38,7 +38,7 @@
       docker://{{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }} \
       --exec=/hyperkube -- kubelet \
       --api_servers=http://127.0.0.1:8080 \
-      --register-with-taints=dedicatedMaster=masters:NoSchedule \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \


### PR DESCRIPTION
removes the register-unschedulable for masters.  now static pods are aligned with master nodes because of taints and tolerations