### PR TITLE
Error handling, separate functions for up/down/update

### DIFF
--- a/down.sh
+++ b/down.sh
@@ -12,9 +12,16 @@ my_dir=$(dirname "${BASH_SOURCE}")
 source "${my_dir}/lib/common.sh"
 
 # capture logs for crash app
-log_file=$"/k2-crash-app/logs"
+crash_app_dir=$"/usr/bin/k2-crash-app"
+logs=$"logs"
+log_file=$crash_app_dir/$logs
 
 # exit trap for crash app
-trap crash_test EXIT
+trap crash_test_down EXIT
 
-ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}" | tee $log_file
+# check crash application directory exists
+if [ -d "$crash_app_dir" ]; then
+	ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}" | tee $log_file
+else 
+	ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}"
+fi

--- a/down.sh
+++ b/down.sh
@@ -3,7 +3,7 @@
 #description     :bring down a kraken cluster
 #author          :Samsung SDSRA
 #==============================================================================
-set -o errexit
+# set -o errexit
 set -o nounset
 set -o pipefail
 
@@ -12,16 +12,14 @@ my_dir=$(dirname "${BASH_SOURCE}")
 source "${my_dir}/lib/common.sh"
 
 # capture logs for crash app
-crash_app_dir=$"/usr/bin/k2-crash-app"
-logs=$"logs"
-log_file=$crash_app_dir/$logs
+LOG_FILE=$"/tmp/crash-logs"
 
 # exit trap for crash app
 trap crash_test_down EXIT
 
-# check crash application directory exists
-if [ -d "$crash_app_dir" ]; then
-	ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}" | tee $log_file
-else 
+K2_CRASH_APP=$(which k2-crash-application)  
+if [ $? -ne 0 ];then  
 	ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}"
+else
+	ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/down.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=down" --tags "${KRAKEN_TAGS}" | tee $LOG_FILE
 fi

--- a/down.sh
+++ b/down.sh
@@ -3,6 +3,8 @@
 #description     :bring down a kraken cluster
 #author          :Samsung SDSRA
 #==============================================================================
+# k2-crash-app is taking over the EXIT in common.sh functions called in the trap
+# leaving this commented out in case we missed an edge case
 # set -o errexit
 set -o nounset
 set -o pipefail

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -94,7 +94,7 @@ function crash_test_up {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
     if [ -f "$K2_CRASH_APP" ]; then
-      /usr/bin/k2-crash-application $LOG_FILE
+      ${K2_CRASH_APP} ${LOG_FILE}
     else 
       echo "k2-crash-application not found, to capture the data from k2 failures, please install"
     fi
@@ -111,7 +111,7 @@ function crash_test_down {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
     if [ -f "$K2_CRASH_APP" ]; then
-      /usr/bin/k2-crash-application $LOG_FILE
+      ${K2_CRASH_APP} ${LOG_FILE}
     else 
       echo "k2-crash-application not found, to capture the data from k2 failures, please install"
     fi
@@ -125,7 +125,7 @@ function crash_test_update {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
     if [ -f "$K2_CRASH_APP" ]; then
-      /usr/bin/k2-crash-application $LOG_FILE
+      ${K2_CRASH_APP} ${LOG_FILE}
     else 
       echo "k2-crash-application not found, to capture the data from k2 failures, please install"
     fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -88,18 +88,61 @@ function show_update_error {
   exit 1
 }
 
-# check if ansible return failure
+# check if ansible return failure on up
 # if failure, send to crash app
-function crash_test {
+function crash_test_up {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
-    /k2-crash-app/k2-crash-application $log_file
-    show_post_cluster_error 
+    # check the logs file exists
+    if [ -f "$log_file" ]; then
+      /usr/bin/k2-crash-app/k2-crash-application $log_file
+      show_post_cluster_error 
+    else 
+      echo "k2-crash log file not found...ignoring"
+      exit $RESULT
+    fi
   else
     show_post_cluster
   fi
   exit $RESULT
 }
+
+# check if ansible return failure on down
+# if failure, send to crash app
+function crash_test_down {
+  RESULT=$?
+  if [ $RESULT -ne 0 ]; then
+    # check the logs file exists
+    if [ -f "$log_file" ]; then
+      /usr/bin/k2-crash-app/k2-crash-application $log_file
+    else 
+      echo "k2-crash log file not found...ignoring"
+      exit $RESULT
+    fi
+  fi
+  exit $RESULT
+}
+
+# check if ansible return failure on update
+# if failure, send to crash app
+function crash_test_update {
+  RESULT=$?
+  if [ $RESULT -ne 0 ]; then
+    # check the logs file exists
+    if [ -f "$log_file" ]; then
+      /usr/bin/k2-crash-app/k2-crash-application $log_file
+      show_update_error
+    else 
+      echo "k2-crash log file not found...ignoring"
+      exit $RESULT
+    fi
+  else
+    show_update
+  fi
+  exit $RESULT
+}
+
+
 
 function control_c() {
   warn "Interrupted!"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -93,14 +93,12 @@ function show_update_error {
 function crash_test_up {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
-    # check the logs file exists
-    if [ -f "$log_file" ]; then
-      /usr/bin/k2-crash-app/k2-crash-application $log_file
-      show_post_cluster_error 
+    if [ -f "$K2_CRASH_APP" ]; then
+      /usr/bin/k2-crash-application $LOG_FILE
     else 
-      echo "k2-crash log file not found...ignoring"
-      exit $RESULT
+      echo "k2-crash-application not found, to capture the data from k2 failures, please install"
     fi
+    show_post_cluster_error 
   else
     show_post_cluster
   fi
@@ -112,12 +110,10 @@ function crash_test_up {
 function crash_test_down {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
-    # check the logs file exists
-    if [ -f "$log_file" ]; then
-      /usr/bin/k2-crash-app/k2-crash-application $log_file
+    if [ -f "$K2_CRASH_APP" ]; then
+      /usr/bin/k2-crash-application $LOG_FILE
     else 
-      echo "k2-crash log file not found...ignoring"
-      exit $RESULT
+      echo "k2-crash-application not found, to capture the data from k2 failures, please install"
     fi
   fi
   exit $RESULT
@@ -128,14 +124,12 @@ function crash_test_down {
 function crash_test_update {
   RESULT=$?
   if [ $RESULT -ne 0 ]; then
-    # check the logs file exists
-    if [ -f "$log_file" ]; then
-      /usr/bin/k2-crash-app/k2-crash-application $log_file
-      show_update_error
+    if [ -f "$K2_CRASH_APP" ]; then
+      /usr/bin/k2-crash-application $LOG_FILE
     else 
-      echo "k2-crash log file not found...ignoring"
-      exit $RESULT
+      echo "k2-crash-application not found, to capture the data from k2 failures, please install"
     fi
+    show_update_error
   else
     show_update
   fi

--- a/up.sh
+++ b/up.sh
@@ -15,9 +15,16 @@ source "${my_dir}/lib/common.sh"
 trap control_c SIGINT
 
 # capture logs for crash app
-log_file=$"/k2-crash-app/logs"
+crash_app_dir=$"/usr/bin/k2-crash-app"
+logs=$"logs"
+log_file=$crash_app_dir/$logs
 
 # exit trap for crash app
-trap crash_test EXIT
+trap crash_test_up EXIT
 
-DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" | tee $log_file
+# check crash application directory exists
+if [ -d "$crash_app_dir" ]; then
+	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" | tee $log_file
+else 
+	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}"
+fi

--- a/up.sh
+++ b/up.sh
@@ -3,6 +3,8 @@
 #description     :bring up a kraken cluster
 #author          :Samsung SDSRA
 #==============================================================================
+# k2-crash-app is taking over the EXIT in common.sh functions called in the trap
+# leaving this commented out in case we missed an edge case
 # set -o errexit
 set -o nounset
 set -o pipefail

--- a/up.sh
+++ b/up.sh
@@ -3,7 +3,7 @@
 #description     :bring up a kraken cluster
 #author          :Samsung SDSRA
 #==============================================================================
-set -o errexit
+# set -o errexit
 set -o nounset
 set -o pipefail
 
@@ -15,16 +15,14 @@ source "${my_dir}/lib/common.sh"
 trap control_c SIGINT
 
 # capture logs for crash app
-crash_app_dir=$"/usr/bin/k2-crash-app"
-logs=$"logs"
-log_file=$crash_app_dir/$logs
+LOG_FILE=$"/tmp/crash-logs"
 
 # exit trap for crash app
 trap crash_test_up EXIT
 
-# check crash application directory exists
-if [ -d "$crash_app_dir" ]; then
-	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" | tee $log_file
-else 
+K2_CRASH_APP=$(which k2-crash-application)  
+if [ $? -ne 0 ];then  
 	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}"
+else
+	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/up.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=up" --tags "${KRAKEN_TAGS}" | tee $LOG_FILE
 fi

--- a/update.sh
+++ b/update.sh
@@ -3,6 +3,8 @@
 #description     :update kubernetes version on AWS after changing config file to new version
 #author          :Samsung SDSRA
 #==============================================================================
+# k2-crash-app is taking over the EXIT in common.sh functions called in the trap
+# leaving this commented out in case we missed an edge case
 # set -o errexit
 set -o nounset
 set -o pipefail

--- a/update.sh
+++ b/update.sh
@@ -19,11 +19,18 @@ source "${my_dir}/lib/common.sh"
 trap control_c SIGINT
 
 # capture logs for crash app
-log_file=$"/k2-crash-app/logs"
+crash_app_dir=$"/usr/bin/k2-crash-app"
+logs=$"logs"
+log_file=$crash_app_dir/$logs
 
 # exit trap for crash app
-trap crash_test EXIT
+trap crash_test_update EXIT
 
-DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" || show_update_error
+# check crash application directory exists
+if [ -d "$crash_app_dir" ]; then
+	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" | tee $log_file
+else 
+	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" || show_update_error
+fi
 
 show_update

--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 #description     :update kubernetes version on AWS after changing config file to new version
 #author          :Samsung SDSRA
 #==============================================================================
-set -o errexit
+# set -o errexit
 set -o nounset
 set -o pipefail
 
@@ -19,18 +19,14 @@ source "${my_dir}/lib/common.sh"
 trap control_c SIGINT
 
 # capture logs for crash app
-crash_app_dir=$"/usr/bin/k2-crash-app"
-logs=$"logs"
-log_file=$crash_app_dir/$logs
+LOG_FILE=$"/tmp/crash-logs"
 
 # exit trap for crash app
 trap crash_test_update EXIT
 
-# check crash application directory exists
-if [ -d "$crash_app_dir" ]; then
-	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" | tee $log_file
-else 
+K2_CRASH_APP=$(which k2-crash-application)  
+if [ $? -ne 0 ];then  
 	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" || show_update_error
+else
+	DISPLAY_SKIPPED_HOSTS=0 ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost ansible/update.yaml --extra-vars "${KRAKEN_EXTRA_VARS}kraken_action=update" | tee $LOG_FILE
 fi
-
-show_update


### PR DESCRIPTION
Added graceful error handling for cases where someone does not have k2-crash-app installed or log file is not in expected location 

Created 3 functions to deal with up/down/update separately, since each one calls different functions depending on success or failure - at this point I think it would be less confusing and less code to just put the k2-crash-app trigger inline in the up.sh/down.sh/update.sh, like I originally had it, but let me know what you think. 