### PR TITLE
Add helm app registry support

### DIFF
--- a/Documentation/kraken-configs/helmconfigs.md
+++ b/Documentation/kraken-configs/helmconfigs.md
@@ -6,7 +6,7 @@ These are helm charts to be installed on cluster startup
 ### Root Options
 | Key Name | Required     | Type         | Description|
 | -------- | ------------ | ------------ | --- |
-| repos    | __Required__ | Object array | Array of helm repositories |
+| repos    | Optional     | Object array | Array of helm repositories |
 | charts   | __Required__ | Object array | Array of helm charts |
 
 ### Repos Options
@@ -16,14 +16,14 @@ These are helm charts to be installed on cluster startup
 | url      | __Required__ | String | Repository address |
 
 ### Charts Options
-| Key Name  | Required     | Type   | Description|
-| --------- | ------------ | ------ | --- |
-| name      | __Required__ | String | Chart release name |
-| repo      | __Required__ | String | Repository name for the chart |
-| chart     | __Required__ | String | Chart name |
-| version   | __Required__ | String | Chart version |
-| namespace | Optional     | String | Kubernetes namespace to install chart into. Defaults to 'default' |
-| values    | Optional     | Object | Chart values |
+| Key Name                 | Required     | Type   | Description|
+| ---------                | ------------ | ------ | --- |
+| name                     | __Required__ | String | Chart release name |
+| repo __OR__ registry     | __Required__ | String | Repository name for the chart |
+| chart                    | __Required__ | String | Chart name |
+| version                  | __Required__ | String | Chart version |
+| namespace                | Optional     | String | Kubernetes namespace to install chart into. Defaults to 'default' |
+| values                   | Optional     | Object | Chart values |
 
 ###  Example
 ```yaml
@@ -38,8 +38,8 @@ helmConfigs:
         url: https://kubernetes-charts.storage.googleapis.com
     charts:
       - name: heapster
-        repo: atlas
-        chart: heapster
+        registry: quay.io
+        chart: samsung_cnct/heapster
         version: 0.1.0
         namespace: kube-system
       - name: central-logging

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HO
 quay.io/samsung_cnct/kubernetes-dashboard      0.1.0-0
 ```
 
+This indicates that the chart to install is `samsung_cnct/kubernetes-dashboard` from the `quay.io` registry.
+
+
 Or for the legacy repo (deprecated)
 
 ```bash
@@ -325,7 +328,7 @@ NAME                      	VERSION	DESCRIPTION
 atlas/kubernetes-dashboard	0.1.0  	A kubernetes dashboard Helm chart
 ```
 
-This indicates that the file to install is `samsung_cnct/kubernetes-dashboard` from the quay.io registry.
+In this case the chart to install is `kubernetes-dashboard` from the `atlas` repo.
 
 ##### Install Kubernetes Dashboard
 

--- a/README.md
+++ b/README.md
@@ -311,18 +311,26 @@ You can try having helm install a new service, such as the Kubernetes dashboard
 ##### Find Kubernetes Dashboard Version
 
 ```bash
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm registry list quay.io | grep kubernetes-dashboard
+
+quay.io/samsung_cnct/kubernetes-dashboard      0.1.0-0
+```
+
+Or for the legacy repo (deprecated)
+
+```bash
 docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm search kubernetes-dashboard
 
 NAME                      	VERSION	DESCRIPTION                      
 atlas/kubernetes-dashboard	0.1.0  	A kubernetes dashboard Helm chart
 ```
 
-This indicates that the file to install is `atlas/kubernetes-dashboard`.
+This indicates that the file to install is `samsung_cnct/kubernetes-dashboard` from the quay.io registry.
 
 ##### Install Kubernetes Dashboard
 
 ```bash
-docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm install --namespace kube-system atlas/kubernetes-dashboard
+docker run $K2OPTS -e HELM_HOME=$HOME/.kraken/${CLUSTER}/.helm -e KUBECONFIG=$HOME/.kraken/${CLUSTER}/admin.kubeconfig quay.io/samsung_cnct/k2:latest helm registry install --namespace kube-system samsung_cnct/kubernetes-dashboard
 ```
 
 ```bash

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -21,10 +21,11 @@ definitions:
           url: https://kubernetes-charts.storage.googleapis.com
       charts:
         - name: heapster
-          repo: atlas
-          chart: heapster
+          registry: quay.io
+          chart: samsung_cnct/heapster
           version: 0.1.0
           namespace: kube-system
+          
   fabricConfigs:
     - &defaultCanalFabric
       name: defaultCanalFabric

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -23,7 +23,7 @@ definitions:
         - name: heapster
           registry: quay.io
           chart: samsung_cnct/heapster
-          version: 0.1.0
+          version: 0.1.0-0
           namespace: kube-system
           
   fabricConfigs:

--- a/ansible/roles/kraken.provider/kraken.provider.gke/README.md
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/README.md
@@ -59,8 +59,8 @@ deployment:
     services:
       -
         name: podpincher
-        repo: atlas
-        chart: podpincher
+        registry: quay.io
+        chart: samsung_cnct/podpincher
         version: 0.1.0
 ```
 

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -95,11 +95,17 @@
   with_items: "{{ cluster_repos }}"
   when: cluster_repos is defined and (helm_command is defined)
 
-- name: Save all config values to files
+- name: Save config values to files for repo charts
   template: src=service-values.yaml.jinja2
     dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.repo }}-{{ item.name }}.helmvalues"
   with_items: "{{ cluster_services }}"
-  when: cluster_services is defined
+  when: cluster_services is defined and (item.repo is defined)
+
+- name: Save config values to files for registry charts
+  template: src=service-values.yaml.jinja2
+    dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.registry }}-{{ item.name }}.helmvalues"
+  with_items: "{{ cluster_services }}"
+  when: cluster_services is defined and (item.registry is defined)
 
 - name: Install charts dry-run
   command: >
@@ -107,7 +113,7 @@
       --name {{ item.name }}
       --version {{ item.version }}
       --namespace {{ item.namespace | default('default') }}
-      --values {{ config_base | expanduser }}/{{ cluster.name }}/{{ item.repo }}-{{ item.name }}.helmvalues
+      --values {{ config_base | expanduser }}/{{ cluster.name }}/{{ item.repo }}-{{ item.name | replace('/','_') }}.helmvalues
       --dry-run
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
@@ -116,7 +122,7 @@
   register: install_dry_out
   when: (cluster_services is defined) and (cluster.helmConfig.debug is defined) and (cluster.helmConfig.debug == True) and (helm_command is defined)
 
-- name: Install charts
+- name: Install charts from repo
   command: >
     {{ helm_command }} install {{ item.repo }}/{{ item.chart }}
       --name {{ item.name }}
@@ -127,4 +133,16 @@
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
   with_items: "{{ cluster_services }}"
-  when: (cluster_services is defined) and (helm_command is defined)
+  when: (cluster_services is defined) and (helm_command is defined) and (item.repo is defined)
+
+- name: Install charts from registry
+  command: >
+    {{ helm_command }} registry install {{ item.registry }}/{{ item.chart }}@{{ item.version }} --
+      --name {{ item.name }}
+      --namespace {{ item.namespace | default('default') }}
+      --values {{ config_base | expanduser }}/{{ cluster.name }}/{{ item.registry }}-{{ item.name | replace('/','_') }}.helmvalues
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  with_items: "{{ cluster_services }}"
+  when: (cluster_services is defined) and (helm_command is defined) and (item.registry is defined)

--- a/schemas/config/v1/helmChart.json
+++ b/schemas/config/v1/helmChart.json
@@ -14,6 +14,10 @@
       "description": "Repository to pull this chart from - referenced by helm application.",
       "type": "string"
     },
+    "registry": {
+      "description": "Registry to pull this chart from - referenced by helm application.",
+      "type": "string"
+    },
     "chart": {
       "description": "Actual name of chart in the repository - referenced by helm application.",
       "type": "string"
@@ -26,9 +30,15 @@
 
   "required": [
     "name",
-    "repo",
     "chart",
     "version"
+  ],
+
+  "oneOf": [
+      { "required":
+          [ "repo" ] },
+      { "required":
+          [ "registry" ] }
   ],
 
   "type": "object"


### PR DESCRIPTION
Add support for the helm (app registry plugin)[https://github.com/app-registry/appr-helm-plugin] to allow version pinned charts to be used in k2 configs.

Depends on https://github.com/samsung-cnct/k2-tools/pull/84