### PR TITLE
do not use $0 for call to mktemp

### DIFF
--- a/computed_kubectl.sh
+++ b/computed_kubectl.sh
@@ -8,7 +8,7 @@ set -o nounset
 set -o pipefail
 
 my_dir=$(dirname "${BASH_SOURCE}")
-VERSIONFILE=$(mktemp /tmp/$0.XXXXXX)
+VERSIONFILE=$(mktemp /tmp/computed_kubectl.XXXXXX)
 rm ${VERSIONFILE}
 trap '{ rm -f -- "${VERSIONFILE}"; }' INT TERM HUP EXIT
 # Call separate script to hide our args from lib/common.sh

--- a/max_k8s_version.sh
+++ b/max_k8s_version.sh
@@ -11,10 +11,12 @@ set -o pipefail
 my_dir=$(dirname "${BASH_SOURCE}")
 
 OUTFILE=$1
-
+if [ -z ${OUTFILE} ]; then 
+  echo "must specify a file to save the max version too"
+  exit 1
 if [ ! -f $OUTFILE ]; then
   echo "first arg must be a pre-created file.  should be created with mktemp"
-  exit 1
+  exit 2
 fi
 
 shift

--- a/max_k8s_version.sh
+++ b/max_k8s_version.sh
@@ -11,6 +11,12 @@ set -o pipefail
 my_dir=$(dirname "${BASH_SOURCE}")
 
 OUTFILE=$1
+
+if [ ! -f $OUTFILE ]; then
+  echo "first arg must be a pre-created file.  should be created with mktemp"
+  exit 1
+fi
+
 shift
 source "${my_dir}/lib/common.sh"
 


### PR DESCRIPTION
$0 will contain the entire path being called which can inject
additional path segments into the file name.  this causes
problems.

the desire was to have the base name that mktemp creates be the
script name so its hardcoded now