### PR TITLE
use GKE default of 1.6.4

### DIFF
--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -121,7 +121,7 @@ definitions:
     - &defaultKube
       name: defaultKube
       kind: kubernetes
-      version: v1.6.6
+      version: v1.6.4
       hyperkubeLocation: gcr.io/google_containers/hyperkube
   containerConfigs:
     - &defaultDocker


### PR DESCRIPTION
part of weekly review, this will knock the CI runs back to 4 minutes instead of 45 for the GKE path.