### PR TITLE
don't use tilde, use $HOME

### DIFF
--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -158,7 +158,7 @@ definitions:
       kind: keyPair
       providerConfig:
         serviceAccount: patrickrobot@k8s-work.iam.gserviceaccount.com
-        serviceAccountKeyFile:  ~/.config/gcloud/patrickRobot.json
+        serviceAccountKeyFile:  $HOME/.config/gcloud/patrickRobot.json
   kubeAuth:
    - &defaultKubeAuth
       authz: {}


### PR DESCRIPTION
the aws default uses $HOME and using `~` causes problems in k2cli