### PR TITLE
avoid groovy regex tester fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ podTemplate(label: 'k2', containers: [
 
             //only push from master if we are on samsung-cnct fork
             stage('Publish') {
-                if (env.BRANCH_NAME == "master" && git_uri ==~ "/${github_org}/") {
+                if (env.BRANCH_NAME == "master" && git_uri.contains(github_org)) {
                     kubesh "docker tag quay.io/${quay_org}/k2:k2-${env.JOB_BASE_NAME}-${env.BUILD_ID} quay.io/${quay_org}/k2:latest"
                     kubesh "docker push quay.io/${quay_org}/k2:latest"
                 } else {


### PR DESCRIPTION
The groovy regex tester, `==~` was failing to find the matching text in
every possible test I could throw at it. Instead, use the string method,
`contains` to ensure the git org string exists in the scm uri.