### PR TITLE
allow aws loadbalancers the option to select subnets.

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -10,6 +10,7 @@ definitions:
         cluster_ip: 10.32.0.2
         dns_domain: cluster.local
         namespace: kube-system
+
   helmConfigs:
     - &defaultHelm
       name: defaultHelm
@@ -123,6 +124,7 @@ definitions:
         default: *defaultWeaveFabric
         versions:
           v1.6: *defaultWeaveFabric16
+
   kvStoreConfigs:
     - &defaultEtcd
       name: etcd
@@ -142,6 +144,7 @@ definitions:
       peerPorts: [2382]
       ssl: true
       version: v3.1.0
+
   apiServerConfigs:
     - &defaultApiServer
       name: defaultApiServer
@@ -151,18 +154,21 @@ definitions:
         etcd: *defaultEtcd
       events:
         etcd: *defaultEtcdEvents
+
   kubeConfigs:
     - &defaultKube
       name: defaultKube
       kind: kubernetes
       version: v1.6.7
       hyperkubeLocation: gcr.io/google_containers/hyperkube
+
   containerConfigs:
     - &defaultDocker
       name: defaultDocker
       kind: container
       runtime: docker
       type: distro
+
   osConfigs:
     - &defaultCoreOs
       name: defaultCoreOs
@@ -171,6 +177,7 @@ definitions:
       version: 1409.5.0
       channel: stable
       rebootStrategy: "off"
+
   nodeConfigs:
     - &defaultAwsEtcdNode
       name: defaultAwsEtcdNode
@@ -334,6 +341,7 @@ definitions:
               delete_on_termination: true
               snapshot_id:
               encrypted: false
+
   providerConfigs:
     - &defaultAws
       name: defaultAws

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -10,6 +10,13 @@ variable "master_key_name" {}
 {% for subnet in master.nodeConfig.providerConfig.subnet %}
 variable "{{subnet}}_subnet_id" {}
 {% endfor %}
+
+{% if master.apiServerConfig.loadBalancerConfigs is defined %}
+{% for subnet in master.apiServerConfig.loadBalancerConfigs.subnet %}
+variable "{{subnet}}_subnet_id" {}
+{% endfor %}
+{% endif %}
+
 variable "route53_zone_id" {}
 variable "kubernetes_sec_group" {}
 variable "dependency" {}
@@ -113,7 +120,7 @@ resource "aws_launch_configuration" "master_launch_config" {
 }
 
 # if masters are load-balanced with a cloud loadbalancer, we need to define an ELB and a IAM cert to use for SSL
-{% if master.apiServerConfig.loadBalancer == 'cloud'  %}
+{% if master.apiServerConfig.loadBalancer == 'cloud' %}
 
 # Client Auth doesn't work right in amazon ELB
 #resource "aws_iam_server_certificate" "master_cert" {
@@ -125,7 +132,12 @@ resource "aws_launch_configuration" "master_launch_config" {
 resource "aws_elb" "master_elb" {
   name = "${var.master_name}-master-elb"
   cross_zone_load_balancing = true
+  {% if master.apiServerConfig.loadBalancerConfigs is defined %}
+  subnets = [{% set comma = joiner(",") %}{% for subnet in master.apiServerConfig.loadBalancerConfigs.subnet %}{{ comma() }}"${var.{{subnet}}_subnet_id}"{% endfor %}]
+  {% else %}
   subnets = [{% set comma = joiner(",") %}{% for subnet in master.nodeConfig.providerConfig.subnet %}{{ comma() }}"${var.{{subnet}}_subnet_id}"{% endfor %}]
+  {% endif %}
+
   security_groups = ["${var.kubernetes_sec_group}"]
 
   listener {

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.tf.jinja2
@@ -80,6 +80,11 @@ module "master" {
 {% for subnet in node.nodeConfig.providerConfig.subnet %}
   {{subnet}}_subnet_id = "${module.subnet.{{subnet}}_subnet_id}"
 {% endfor %}
+{% if node.apiServerConfig.loadBalancerConfigs is defined %}
+  {% for subnet in node.apiServerConfig.loadBalancerConfigs.subnet %}
+  {{subnet}}_subnet_id = "${module.subnet.{{subnet}}_subnet_id}"
+  {% endfor %}
+{% endif %}
 {% endif %}
 {% endfor %}
   route53_zone_id = "${module.route53.route53_zone_id}"

--- a/schemas/config/v1/apiServerConfig.json
+++ b/schemas/config/v1/apiServerConfig.json
@@ -15,6 +15,10 @@
       "enum": ["cloud", "flipbit"],
       "type": "string"
     },
+    "loadBalancerConfigs": {
+      "description": "Further configuration options for the load balancer.",
+      "$ref": "awsLoadBalancerConfig.json"
+    },
     "state": {
       "etcd": { "$ref": "kvStoreConfig.json" }
     },

--- a/schemas/config/v1/awsLoadBalancerConfig.json
+++ b/schemas/config/v1/awsLoadBalancerConfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/awsLoadBalancerConfig.json",
+  "$$target": "awsLoadBalancerConfig.json",
+  "title": "AWS Load balancer configuration",
+  "description": "AWS Load balancer configuration for Kubernetes API servers",
+
+  "properties": {
+    "subnet": {
+      "description": "List of subnets to use within a region for the cluster. ",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "type": "array"
+
+    }
+  },
+  "required": [
+    "subnet"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
resolves: https://github.com/samsung-cnct/k2/issues/658

- Consistent spacing for the generated config file
- Code to allow subnets for load balancers, (search by name go get ids)
- Removed extraneous loadbalancer config. 