### PR TITLE
k2 expecting to get cluster health from a private topology via ssh

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -19,6 +19,8 @@
   until: etcd_result | succeeded
   retries: "{{ etcd_retries }}"
   delay: "{{ etcd_delay }}"
+  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or
+  ( item.nodeConfig.providerConfig.enablePublicIPs is defined and item.nodeConfig.providerConfig.enablePublicIPs )
 
 - debug:
     var: etcd_result

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -19,8 +19,7 @@
   until: etcd_result | succeeded
   retries: "{{ etcd_retries }}"
   delay: "{{ etcd_delay }}"
-  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or
-  ( item.nodeConfig.providerConfig.enablePublicIPs is defined and item.nodeConfig.providerConfig.enablePublicIPs )
+  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or ( item.nodeConfig.providerConfig.enablePublicIPs is defined and item.nodeConfig.providerConfig.enablePublicIPs )
 
 - debug:
     var: etcd_result


### PR DESCRIPTION
- Added a check to run task: `Wait for etcd cluster to form` only when public ips are available.

should resolve: https://github.com/samsung-cnct/k2/issues/671