### PR TITLE
if in a BYO vpc scenario, do not block for all ELBs

### DIFF
--- a/ansible/roles/kraken.services/tasks/kill-services.yaml
+++ b/ansible/roles/kraken.services/tasks/kill-services.yaml
@@ -127,7 +127,7 @@
   register: elb_facts
   vars:
     vpc_lookup: "elbs[?vpc_id=='{{ vpcid }}']"
-  when: kraken_action == 'down' and cluster.providerConfig.provider == 'aws'
+  when: kraken_action == 'down' and cluster.providerConfig.provider == 'aws' and cluster.providerConfig.existing_vpc is not defined
   until: (elb_facts is none) or (elb_facts | json_query(vpc_lookup) is none) or (elb_facts | json_query(vpc_lookup) | length <= 1)
   retries: 120
   delay: 5


### PR DESCRIPTION
it is probably/guarnateed that there will be ELBs in the VPC that
do not belong to kubernetes.

This doesn't resolve the underlying issue that the ansible module
can easily overwhelm the API threshold but it does unblock people
who certainly don't want to block on this.

long term fix:  #676 

fixes: #635 
fixes: #644 