### PR TITLE
Etcd Node Name Should be Unique for Discovery

### DIFF
--- a/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/etcd.units.etcd.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/etcd.units.etcd.part.jinja2
@@ -34,7 +34,7 @@
      --mount volume=resolv-conf,target=/etc/resolv.conf \
      quay.io/coreos/etcd:{{cluster_node_tuple.1.etcdConfig.version}} \
      -- --data-dir /ephemeral/etcd \
-     --name etcd{{cluster_node_tuple.1.name}} \
+     --name etcd{{cluster_node_tuple.1.name}}${DEFAULT_IPV4} \
 {% if cluster_node_tuple.1.etcdConfig.ssl == true %}
      --peer-client-cert-auth \
      --peer-trusted-ca-file=/etc/etcd/ssl/peer-ca.pem \


### PR DESCRIPTION
Etcd node discovery via DNS SRV requires that the `--name` parameter had a unique value for each node.

Currently all etcd nodes have the name `etcdetcd` and all events nodes have the name `etcdetcdevents`.
This can result in discovery incorrectly thinking all nodes are discovered, when they are not.  

Exact results of this bug are unclear, however clusters may have been evaluated as "up" prematurely.
