### PR TITLE
Check etcd cluster health for all nodes in each etcd cluster. This is…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 github_org             = "samsung-cnct"
 quay_org               = "samsung_cnct"
 
-aws_cloud_test_timeout = 32  // Should be about 16 min (longer due to etcd cluster separation)
+aws_cloud_test_timeout = 32  // Should be about 16 min (or longer due to etcd cluster health checks)
 gke_cloud_test_timeout = 60  // Should be about 4 min but can be as long as 50 for non-default versions
 e2e_test_timeout       = 18  // Should be about 15 min
 cleanup_timeout        = 60  // Should be about 6 min

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -22,9 +22,19 @@
   with_items: "{{ item.count }}"
   loop_control:
     loop_var: idx
-  # See k2/674 for notes on a long term fix to eliminating this when statement.
-  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or item.nodeConfig.providerConfig.enablePublicIPs
+  # See k2/674 for notes on the correct fix to eliminating this when statement.
+  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or
+        item.nodeConfig.providerConfig.enablePublicIPs
 
+# When we have no other way to determine etcd cluster health, wait the maximum
+# expected time. See k2/674 for notes on the correct fix to eliminating this
+# pause.
+- name: Pause when traditional etcd health checks are unavailable
+  pause:
+    seconds: "{{ (etcd_retries * etcd_delay) | int }}"
+  when:
+    - item.nodeConfig.providerConfig.enablePublicIPs is defined
+    - not item.nodeConfig.providerConfig.enablePublicIPs
 - debug:
     var: etcd_result
     verbosity: 0

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -9,7 +9,7 @@
   command: >
     ssh -o StrictHostKeyChecking=no
         -o UserKnownHostsFile=/dev/null
-        -F {{ ssh_config }} {{ item.name }}-1
+        -F {{ ssh_config }} {{ item.name }}-{{ idx }}
         etcdctl --ca-file={{ etcd_cafile }}
                 --cert-file={{ etcd_certfile }}
                 --key-file={{ etcd_keyfile }}
@@ -19,8 +19,12 @@
   until: etcd_result | succeeded
   retries: "{{ etcd_retries }}"
   delay: "{{ etcd_delay }}"
-  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or ( item.nodeConfig.providerConfig.enablePublicIPs is defined and item.nodeConfig.providerConfig.enablePublicIPs )
+  with_items: "{{ item.count }}"
+  loop_control:
+    loop_var: idx
+  # See k2/674 for notes on a long term fix to eliminating this when statement.
+  when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or item.nodeConfig.providerConfig.enablePublicIPs
 
 - debug:
     var: etcd_result
-    verbosity: 1
+    verbosity: 0

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -26,6 +26,13 @@
   when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or
         item.nodeConfig.providerConfig.enablePublicIPs
 
+- name: Fail if any etcd node failed to report healthy
+  fail:
+    msg: >
+      An etcd node failed to report a healthy status. Please run down and
+      reattempt to run up again.
+  when: etcd_result | failed
+
 # When we have no other way to determine etcd cluster health, wait the maximum
 # expected time. See k2/674 for notes on the correct fix to eliminating this
 # pause.
@@ -35,6 +42,7 @@
   when:
     - item.nodeConfig.providerConfig.enablePublicIPs is defined
     - not item.nodeConfig.providerConfig.enablePublicIPs
+
 - debug:
     var: etcd_result
     verbosity: 0

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -26,6 +26,10 @@
   when: item.nodeConfig.providerConfig.enablePublicIPs is undefined or
         item.nodeConfig.providerConfig.enablePublicIPs
 
+- debug:
+    var: etcd_result
+    verbosity: 0
+
 - name: Fail if any etcd node failed to report healthy
   fail:
     msg: >
@@ -42,7 +46,3 @@
   when:
     - item.nodeConfig.providerConfig.enablePublicIPs is defined
     - not item.nodeConfig.providerConfig.enablePublicIPs
-
-- debug:
-    var: etcd_result
-    verbosity: 0


### PR DESCRIPTION
… related

to #673, but in part because of #672, it is not expected to fix either of them.
It only ensure traditional etcd clusters (with public IP addresses) should
start more reliably (all etcd nodes must be healthy, not a quorum of them).

It also includes an unconditional wait for clusters for which we have no way of determining etcd health.