### PR TITLE
Move helm and kubernetes command configuration to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 generated/
 **/*.retry
 .idea
+.vscode
 **/.DS_Store
 *.tgz
 .env/

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,11 +1,11 @@
 # Documentation
 
-
 ## Kraken Configuration File Format
 
 Kraken configuration is done through a yaml file, and is broken up into two sections.  The top of the file will contain the definitions of the component stanzas and the bottom of the file will contain a list of clusters which are composed of the component stanzas.
 
 ### Definitions
+
 * `definitions` - [Definitions of sections](kraken-configs/definitions.md)
   * `dns` - [dns configurations](kraken-configs/dns.md)
   * `helm` - [helm charts configuration](kraken-configs/helmconfigs.md)
@@ -20,13 +20,14 @@ Kraken configuration is done through a yaml file, and is broken up into two sect
   * `keypairs` -[keyPair configuration](kraken-configs/keypair/README.md)
   * `kubeAuth` -[kubeAuth configuration](kraken-configs/kubeauth.md)
 
-### Deployment  
-* `deployment` - [The core of the configuration](kraken-configs/deployment.md)
+### Deployment
 
+* `deployment` - [The core of the configuration](kraken-configs/deployment.md)
 
 ## Additional Guide For Developer
 
 * [Upgrading to newer Kubernetes](./UPGRADING_KUBERNETES.md)
 
 ### Usage For Tags
+
 * `tags` - [Usage for tags](tags/README.md)

--- a/ansible/roles/kraken.cluster_common/templates/v1.5/help.txt.jinja2
+++ b/ansible/roles/kraken.cluster_common/templates/v1.5/help.txt.jinja2
@@ -16,7 +16,7 @@ To ssh:
 
 {% for cluster in kraken_config.clusters %}
 {%   for node in cluster.nodePools       %}
-{%     for number in range(1,node.count) %}
+{%     for number in range(1, node.count + 1) %}
     ssh -F {{ config_base }}/{{ cluster.name }}/ssh_config {{ node.name }}-{{ number }}
 {%     endfor                            %}
 {%   endfor                              %}

--- a/ansible/roles/kraken.config/tasks/check-update.yaml
+++ b/ansible/roles/kraken.config/tasks/check-update.yaml
@@ -4,27 +4,17 @@
     msg: "You must pass an action to update, either --addnodepools <nodepool,names>; --rmnodepools <nodepool,names> or --nodepools <nodepool,names>"
   when:
     add_nodepools == "" and remove_nodepools == "" and update_nodepools == ""
-- set_fact:
-    cluster: "{{ a_cluster }}"
 
 - name: Set kubeconfig path
   set_fact:
     kubeconfig: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
 
-- name: Set minor k8s version
-  set_fact:
-    kubernetes_minor_version: "{{ item.kubeConfig.version[0:(item.kubeConfig.version.find('.', 3 ))] }}"
-  with_items:
-    - "{{ cluster.nodePools }}"
-  when: (item.apiServerConfig is defined) or (cluster.providerConfig.provider == 'gke')
-
-- name: Get kubectl
-  set_fact:
-    kubectl: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/kubectl"
 
 - name: Get currently deployed nodepools
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig }} get nodes -o jsonpath='{range .items[*]}{.metadata.labels.nodepool}{"\n"}{end}'
+  vars:
+    kubectl: "{{ kubectl_commands[cluster.name] }}"
   register: current_nodepools
 
 - name: Create list of current nodepool names

--- a/ansible/roles/kraken.config/tasks/cluster_loop.yaml
+++ b/ansible/roles/kraken.config/tasks/cluster_loop.yaml
@@ -1,0 +1,51 @@
+---
+- set_fact:
+    cluster: "{{ a_cluster }}"
+
+- name: Prevent up if cluster is already up
+  include: check-clusters-lock.yaml
+  when: kraken_action =='up'
+
+- name: Verify all clusters in the clusters list have names
+  fail:
+    msg: "Make sure that all 'clusters.name' are defined in {{ config_file }}"
+  when: item.name | is_empty
+
+- name: Ensure each nodePool corresponds to exactly one of the node roles (i.e. etcd, master, or node)
+  fail:
+    msg: "({{ i.0.name }}, {{ i.1.name }}) corresponds to more than one node role"
+  with_subelements:
+    - nodePools
+  loop_control:
+    loop_var: pool
+  when: (pool.etcdConfig is defined and (pool.apiServerConfig is defined or pool.kubeConfig is defined))
+         or (pool.apiServerConfig is defined and pool.kubeConfig is undefined)
+         or (pool.etcdConfig is undefined and pool.kubeConfig is undefined)
+
+- include: setup.yaml
+
+- name: Set kubernetes minor versions for each aws or gke cluster
+  set_fact:
+    kubernetes_minor_versions: "{{ kubernetes_minor_versions | default({}) |combine
+      (
+        { item.0.name: masterVersion[0:(masterVersion.find('.', 3 ))] }
+      )
+     }}"
+  with_subelements:
+    - nodePools
+  when: (item.apiServerConfig is defined) or (cluster.providerConfig.provider == 'gke')
+  vars:
+    masterVersion: "{{ item.kubeConfig.version }}"
+
+- name: Look up and set k8s minor version for this cluster
+  set_fact:
+    kubernetes_minor_version: "{{ kubernetes_minor_versions[cluster.name] }}"
+
+- include: helm.yaml
+- include: kubectl.yaml
+
+- include: set-oidc-info.yaml
+  when: "a_cluster.kubeAuth.authn.oidc is defined"
+
+- include: check-update.yaml
+  when: kraken_action == 'update'

--- a/ansible/roles/kraken.config/tasks/cluster_loop.yaml
+++ b/ansible/roles/kraken.config/tasks/cluster_loop.yaml
@@ -9,13 +9,13 @@
 - name: Verify all clusters in the clusters list have names
   fail:
     msg: "Make sure that all 'clusters.name' are defined in {{ config_file }}"
-  when: item.name | is_empty
+  when: cluster.name | is_empty
 
 - name: Ensure each nodePool corresponds to exactly one of the node roles (i.e. etcd, master, or node)
   fail:
-    msg: "({{ i.0.name }}, {{ i.1.name }}) corresponds to more than one node role"
-  with_subelements:
-    - nodePools
+    msg: "({{ cluster.name }}, {{ pool.name }}) corresponds to more than one node role"
+  with_items:
+    - "{{ cluster.nodePools }}"
   loop_control:
     loop_var: pool
   when: (pool.etcdConfig is defined and (pool.apiServerConfig is defined or pool.kubeConfig is defined))
@@ -28,11 +28,11 @@
   set_fact:
     kubernetes_minor_versions: "{{ kubernetes_minor_versions | default({}) |combine
       (
-        { item.0.name: masterVersion[0:(masterVersion.find('.', 3 ))] }
+        { cluster.name: masterVersion[0:(masterVersion.find('.', 3 ))] }
       )
      }}"
-  with_subelements:
-    - nodePools
+  with_items:
+    - "{{ cluster.nodePools }}"
   when: (item.apiServerConfig is defined) or (cluster.providerConfig.provider == 'gke')
   vars:
     masterVersion: "{{ item.kubeConfig.version }}"
@@ -45,7 +45,7 @@
 - include: kubectl.yaml
 
 - include: set-oidc-info.yaml
-  when: "a_cluster.kubeAuth.authn.oidc is defined"
+  when: cluster.kubeAuth.authn.oidc is defined
 
 - include: check-update.yaml
   when: kraken_action == 'update'

--- a/ansible/roles/kraken.config/tasks/helm-versioning.yaml
+++ b/ansible/roles/kraken.config/tasks/helm-versioning.yaml
@@ -1,5 +1,5 @@
 - set_fact:
-    cluster: "{{ item }}"
+    cluster: "{{ a_cluster }}"
 
 - name: Look up and set k8s minor version for this cluster
   set_fact:

--- a/ansible/roles/kraken.config/tasks/helm-versioning.yaml
+++ b/ansible/roles/kraken.config/tasks/helm-versioning.yaml
@@ -12,12 +12,7 @@
     helm_override_key: "helm_override_{{cluster.name}}"
 
 - name: Check if helm version exists
-  stat: path=/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm
   register: helm_available
-
-- name: Set helm_available
-  set_fact:
-    helm_available: "{{ helm_available.stat.exists }}"
 
 - name: Stop and print out message if helm is not available and helm_override has not been set in either env or config
   fail:
@@ -25,19 +20,18 @@
     export {{ helm_override_key }}=false and then run cluster up again.
     If you would like to use the latest version of helm instead, execute:
     export {{ helm_override_key }}=true and then run your cluster up again."
-  when: helm_available == false and helm_override == "" and kraken_action != "down"
   vars:
     helm_override_key: "helm_override_{{cluster.name}}"
+    path: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm"
+  when: 
+    - not (path | is_file) 
+    - helm_override == "" 
+    - kraken_action != "down"
 
-- name: Keep track of helm overrides by cluster name
+- name: Set helm command for cluster {{ cluster.name }}
   set_fact:
-    helm_overrides: "{{ helm_overrides | default({}) | combine(key_val) }}"
-  when: helm_override != ""
+    helm_commands: "{{ { cluster.name : helm_command } | combine(helm_command) }}"
   vars:
-    key_val: "{{ { cluster.name : helm_override } }}"
-
-- name: Keep track of helm availability by cluster name
-  set_fact:
-    helm_availabilities: "{{ helm_availabilities | default({}) | combine(key_val) }}"
-  vars:
-    key_val: "{{ { cluster.name: helm_available } }}"
+    path: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm"
+    latest: "/opt/cnct/kubernetes/latest/bin/helm"
+    helm_command: "{{ ( path | is_file ) | ternary( path, latest ) }}"

--- a/ansible/roles/kraken.config/tasks/helm.yaml
+++ b/ansible/roles/kraken.config/tasks/helm.yaml
@@ -20,8 +20,8 @@
 
 - name: Set helm facts for cluster {{ cluster.name }}
   set_fact:
-    helm_commands: "{{ { cluster.name : helm_command } | combine( helm_command ) }}"
-    helm_homes: "{{ { cluster.name : helm_home } | combine( helm_homes )}}
+    helm_commands: "{{ { cluster.name : helm_command } | combine( helm_commands | default( {} ) ) }}"
+    helm_homes: "{{ { cluster.name : helm_home } | combine( helm_homes | default( {} ) )}}"
   vars:
     path: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm"
     latest: "/opt/cnct/kubernetes/latest/bin/helm"

--- a/ansible/roles/kraken.config/tasks/helm.yaml
+++ b/ansible/roles/kraken.config/tasks/helm.yaml
@@ -1,18 +1,8 @@
-- set_fact:
-    cluster: "{{ a_cluster }}"
-
-- name: Look up and set k8s minor version for this cluster
-  set_fact:
-    kubernetes_minor_version: "{{ kubernetes_minor_versions[cluster.name] }}"
-
 - name: Set overall helm_override to env var if it has been set, config var if not
   set_fact:
     helm_override: "{{ (lookup('env', helm_override_key) != '') | ternary(lookup('env', helm_override_key), cluster.helmOverride | default('')) }}"
   vars:
     helm_override_key: "helm_override_{{cluster.name}}"
-
-- name: Check if helm version exists
-  register: helm_available
 
 - name: Stop and print out message if helm is not available and helm_override has not been set in either env or config
   fail:
@@ -28,10 +18,19 @@
     - helm_override == "" 
     - kraken_action != "down"
 
-- name: Set helm command for cluster {{ cluster.name }}
+- name: Set helm facts for cluster {{ cluster.name }}
   set_fact:
-    helm_commands: "{{ { cluster.name : helm_command } | combine(helm_command) }}"
+    helm_commands: "{{ { cluster.name : helm_command } | combine( helm_command ) }}"
+    helm_homes: "{{ { cluster.name : helm_home } | combine( helm_homes )}}
   vars:
     path: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm"
     latest: "/opt/cnct/kubernetes/latest/bin/helm"
     helm_command: "{{ ( path | is_file ) | ternary( path, latest ) }}"
+    helm_home: "{{ config_base | expanduser }}/{{ cluster.name }}/.helm"
+
+- name: Create Helm home
+  file:
+    path: "{{ helm_home }}"
+    state: directory
+  vars:
+    helm_home: "{{ helm_homes[cluster.name] }}"

--- a/ansible/roles/kraken.config/tasks/kubectl.yaml
+++ b/ansible/roles/kraken.config/tasks/kubectl.yaml
@@ -1,0 +1,5 @@
+- name: Set kubectl command for cluster {{ cluster.name }}
+  set_fact:
+    kubectl_commands: "{{ { cluster.name : kubectl_command } | combine(kubectl_command) }}"
+  vars:
+    kubectl_command: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/kubectl"

--- a/ansible/roles/kraken.config/tasks/kubectl.yaml
+++ b/ansible/roles/kraken.config/tasks/kubectl.yaml
@@ -1,5 +1,5 @@
 - name: Set kubectl command for cluster {{ cluster.name }}
   set_fact:
-    kubectl_commands: "{{ { cluster.name : kubectl_command } | combine(kubectl_command) }}"
+    kubectl_commands: "{{ { cluster.name : kubectl_command } | combine(kubectl_commands | default( {} )) }}"
   vars:
     kubectl_command: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/kubectl"

--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -123,6 +123,8 @@
 - include: helm-versioning.yaml
   with_items:
     - "{{ kraken_config.clusters }}"
+  loop_control:
+    loop_var: a_cluster
 
 - include: check-update.yaml
   with_items:

--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -75,76 +75,10 @@
          of API version {{ kraken_config_user.version }}.
   when: not validation.result.is_valid
 
-- name: Verify all clusters in the clusters list have names
-  fail:
-    msg: "Make sure that all 'clusters.name' are defined in {{ config_file }}"
-  when: item.name | is_empty
-  with_items:
-    - "{{ kraken_config.clusters }}"
-
 - name: Do not allow multiple clusters in config
   fail:
     msg: "Multiple clusters are not yet supported in k2"
   when: kraken_config.clusters | length > 1 | int
-
-- include: check-clusters-lock.yaml
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: kraken_action =='up'
-
-- name: Ensure each nodePool corresponds to exactly one of the node roles (i.e. etcd, master, or node)
-  fail:
-    msg: "({{ i.0.name }}, {{ i.1.name }}) corresponds to more than one node role"
-  with_subelements:
-    - "{{ kraken_config.clusters }}"
-    - nodePools
-  loop_control:
-    loop_var: i
-  when: (i.1.etcdConfig is defined and (i.1.apiServerConfig is defined or i.1.kubeConfig is defined))
-         or (i.1.apiServerConfig is defined and i.1.kubeConfig is undefined)
-         or (i.1.etcdConfig is undefined and i.1.kubeConfig is undefined)
-
-- name: Set kubernetes minor versions for each aws or gke cluster
-  set_fact:
-    kubernetes_minor_versions: "{{ kubernetes_minor_versions| default({}) |combine
-      (
-        { item.0.name: masterVersion[0:(masterVersion.find('.', 3 ))] }
-      )
-     }}"
-  with_subelements:
-    - "{{ kraken_config.clusters }}"
-    - nodePools
-  when: (item.1.apiServerConfig is defined) or (item.0.providerConfig.provider == 'gke')
-  vars:
-    masterVersion: "{{ item.1.kubeConfig.version }}"
-
-- include: helm-versioning.yaml
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-
-- include: check-update.yaml
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: kraken_action == 'update'
-
-- include: setup.yaml
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-
-- include: set-oidc-info.yaml
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: "a_cluster.kubeAuth.authn.oidc is defined"
 
 # version_query and version_outfile are passed in by the caller
 - name: Collect versions
@@ -156,3 +90,9 @@
     src: query_max_version.jinja2
     dest: "{{ version_outfile | realpath }}"
   when: kraken_action == 'max_k8s_version'
+
+- include: cluster_loop.yaml
+  with_items:
+    - "{{ kraken_config.clusters }}"
+  loop_control:
+    loop_var: a_cluster

--- a/ansible/roles/kraken.config/tasks/setup.yaml
+++ b/ansible/roles/kraken.config/tasks/setup.yaml
@@ -1,7 +1,4 @@
 ---
-- set_fact:
-    cluster: "{{ a_cluster }}"
-
 - name: Verify cloud provider is supported
   fail:
     msg: |

--- a/ansible/roles/kraken.services/tasks/aws_config.yaml
+++ b/ansible/roles/kraken.services/tasks/aws_config.yaml
@@ -6,13 +6,13 @@
     cluster.providerConfig.authentication.credentialsProfile | is_empty
 
 - name: set accessKey if unset and credentialsFile set
-  set_fact: 
+  set_fact:
     cluster: "{{ cluster |combine({'providerConfig':{'authentication':{'accessKey': lookup('ini', 'aws_access_key_id section=' + cluster.providerConfig.authentication.credentialsProfile + ' file=' + cluster.providerConfig.authentication.credentialsFile)}}}, recursive=True)}}"
   when:
     cluster.providerConfig.authentication.accessKey | is_empty and cluster.providerConfig.authentication.credentialsFile | is_empty == False
 
 - name: set accessSecret if unset and credentialsFile set
-  set_fact: 
+  set_fact:
     cluster: "{{ cluster | combine({'providerConfig':{'authentication':{'accessSecret': lookup('ini', 'aws_secret_access_key section=' + cluster.providerConfig.authentication.credentialsProfile + ' file=' + cluster.providerConfig.authentication.credentialsFile)}}}, recursive=True)}}"
   when:
     cluster.providerConfig.authentication.accessSecret | is_empty and cluster.providerConfig.authentication.credentialsFile | is_empty == False

--- a/ansible/roles/kraken.services/tasks/generate-oidc-cert.yaml
+++ b/ansible/roles/kraken.services/tasks/generate-oidc-cert.yaml
@@ -1,7 +1,7 @@
 ---
 - set_fact:
     cluster: "{{ a_cluster }}"
-    
+
 - name: Generate dex key
   command: >
     openssl genrsa -out {{ config_base | expanduser }}/{{ cluster.name }}/certs/dex-key.pem 2048

--- a/ansible/roles/kraken.services/tasks/kill-services.yaml
+++ b/ansible/roles/kraken.services/tasks/kill-services.yaml
@@ -6,16 +6,6 @@
   set_fact:
     kubernetes_minor_version: "{{ kubernetes_minor_versions[cluster.name] }}"
 
-- name: Execute appropriate helm per minor version
-  set_fact:
-    helm_command: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm"
-  when: helm_availabilities[cluster.name] == true
-
-- name: In case of helm not being available, always override to latest helm
-  set_fact:
-    helm_command: "/opt/cnct/kubernetes/latest/bin/helm"
-  when: (helm_availabilities[cluster.name] == false)
-
 - name: Execute appropriate kubectl per minor version
   set_fact:
     kubectl: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/kubectl"
@@ -24,7 +14,6 @@
     cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
     cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
     kubeconfig: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
-    helm_home: "{{ config_base | expanduser }}/{{ cluster.name }}/.helm"
     cluster_namespaces: []
 
 - set_fact:
@@ -42,20 +31,17 @@
   ignore_errors: yes
   failed_when: false
 
-- name: Create Helm home
-  file:
-    path: "{{ helm_home }}"
-    state: directory
-
 - name: Clean up releases
   command: >
-    {{ helm_command }} delete --purge {{ item.name }}
+    {{ helm_commands[cluster.name] }} delete --purge {{ item.name }}
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
-    HELM_HOME: "{{ helm_home }}"
+    HELM_HOME: "{{ helm_homes[cluster.name] }}"
   with_items: "{{ cluster_services }}"
   ignore_errors: yes
-  when: "'Error' not in tiller_present.stderr and not tiller_present | skipped  and (helm_command is defined) "
+  when: 
+    - 'Error' not in tiller_present.stderr 
+    - not (tiller_present | skipped)
 
 - name: Clean up tiller if present
   command: >

--- a/ansible/roles/kraken.services/tasks/kill-services.yaml
+++ b/ansible/roles/kraken.services/tasks/kill-services.yaml
@@ -2,18 +2,11 @@
 - set_fact:
     cluster: "{{ a_cluster }}"
 
-- name: Look up and set k8s minor version for this cluster
-  set_fact:
-    kubernetes_minor_version: "{{ kubernetes_minor_versions[cluster.name] }}"
-
-- name: Execute appropriate kubectl per minor version
-  set_fact:
-    kubectl: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/kubectl"
-
 - set_fact:
     cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
     cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
     kubeconfig: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
+    kubectl: "{{ kubectl_commands[cluster.name] }}"
     cluster_namespaces: []
 
 - set_fact:
@@ -39,14 +32,16 @@
     HELM_HOME: "{{ helm_homes[cluster.name] }}"
   with_items: "{{ cluster_services }}"
   ignore_errors: yes
-  when: 
-    - 'Error' not in tiller_present.stderr 
+  when:
     - not (tiller_present | skipped)
+    - tiller_present.stderr.find("Error") != -1
 
 - name: Clean up tiller if present
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig }} delete deployment {{ tiller }} --namespace=kube-system
-  when: "'Error' not in tiller_present.stderr and not tiller_present | skipped "
+  when:
+    - not (tiller_present | skipped)
+    - tiller_present.stderr.find("Error") != -1
   ignore_errors: yes
 
 - name: Collect all services
@@ -83,7 +78,7 @@
 
 - name: Delete all service namespaces
   command: >
-    kubectl --kubeconfig={{ kubeconfig }} delete namespace {{ item }}
+    {{ kubectl }} --kubeconfig={{ kubeconfig }} delete namespace {{ item }}
   with_items: "{{ cluster_namespaces }}"
   when: cluster_namespaces is defined
   ignore_errors: yes

--- a/ansible/roles/kraken.services/tasks/main.yaml
+++ b/ansible/roles/kraken.services/tasks/main.yaml
@@ -4,14 +4,19 @@
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: (a_cluster.kubeAuth.authn.oidc is defined) and (kraken_action == 'up') and (a_cluster.clusterServices is defined)
+  when:
+    - a_cluster.kubeAuth.authn.oidc is defined
+    - kraken_action == 'up'
+    - a_cluster.clusterServices is defined
 
 - include: kill-dns.yaml
   with_items:
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: (kraken_action == 'down') and (a_cluster.providerConfig.provider in ['aws'])
+  when:
+    - kraken_action == 'down'
+    - a_cluster.providerConfig.provider in ['aws']
   static: no
 
 - include: run-dns.yaml
@@ -19,7 +24,9 @@
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: (kraken_action == 'up') and (a_cluster.providerConfig.provider in ['aws'])
+  when:
+    - kraken_action == 'up'
+    - a_cluster.providerConfig.provider in ['aws']
   static: no
 
 - include: kill-services.yaml
@@ -34,5 +41,7 @@
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: (kraken_action == 'up') and (a_cluster.helmConfig is defined)
+  when:
+    - kraken_action == 'up'
+    - a_cluster.helmConfig is defined
   static: no

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -1,51 +1,40 @@
 ---
-
-- set_fact:
+- name: set cluster fact
+  set_fact:
     cluster: "{{ a_cluster }}"
 
-- name: Look up and set k8s minor version for this cluster
+- name: set facts for run-services
   set_fact:
-    kubernetes_minor_version: "{{ kubernetes_minor_versions[cluster.name] }}"
-
-- name: Execute appropriate kubectl per minor version
-  set_fact:
-    kubectl: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/kubectl"
-
-- name: Execute appropriate helm per minor version
-  set_fact:
-    helm_command: "/opt/cnct/kubernetes/{{ kubernetes_minor_version }}/bin/helm"
-  when: helm_availabilities[cluster.name] == true
-
-- name: In case of helm not being available, if override was specified, override to latest helm
-  set_fact:
-    helm_command: "/opt/cnct/kubernetes/latest/bin/helm"
-  when: (helm_availabilities[cluster.name] == false) and (helm_overrides[cluster.name] == true)
-
-- set_fact:
     cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
     cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
+    helm_command: "{{ helm_commands[cluster.name] }}"
+    kubectl: "{{ kubectl_commands[cluster.name] }}"
     kubeconfig: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
     helm_home: "{{ config_base | expanduser }}/{{ cluster.name }}/.helm"
-
-- name: Create Helm home
-  file:
-    path: "{{ helm_home }}"
-    state: directory
 
 - name: create debug helm command string
   set_fact:
     helm_command: "{{ helm_command }} --debug"
-  when: (cluster.helmConfig.debug is defined) and (cluster.helmConfig.debug == True) and (helm_command is defined)
+  when:
+    - cluster.helmConfig.debug is defined
+    - cluster.helmConfig.debug == True
+    - helm_command is defined
 
 - name: create helm init command string
   set_fact:
     helm_init_command: "{{ helm_command }} init"
-  when: ((tiller_image is undefined) or (tiller_image is none) or (tiller_image | trim == '')) and (helm_command is defined)
+  when:
+    - ((tiller_image is undefined) or (tiller_image is none) or (tiller_image | trim == ''))
+    - helm_command is defined
 
 - name: create helm init command string
   set_fact:
     helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }}"
-  when: (tiller_image is defined) and (tiller_image is not none) and (tiller_image | trim != '') and (helm_command is defined)
+  when:
+    - tiller_image is defined
+    - tiller_image is not none
+    - tiller_image | trim != ''
+    - helm_command is defined
 
 - name: Init helm dry-run
   command: >
@@ -54,7 +43,10 @@
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
   register: init_dry_out
-  when: (cluster.helmConfig.debug is defined) and (cluster.helmConfig.debug == True) and (helm_command is defined)
+  when:
+    - cluster.helmConfig.debug is defined
+    - cluster.helmConfig.debug == True
+    - helm_command is defined
 
 - name: Init helm
   command: >
@@ -82,7 +74,9 @@
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
   with_items: "{{ cluster_repos }}"
-  when: (cluster_repos is defined) and (helm_command is defined)
+  when:
+    - cluster_repos is defined
+    - helm_command is defined
   ignore_errors: yes
   failed_when: false
 
@@ -93,19 +87,25 @@
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
   with_items: "{{ cluster_repos }}"
-  when: cluster_repos is defined and (helm_command is defined)
+  when:
+    - cluster_repos is defined
+    - helm_command is defined
 
 - name: Save config values to files for repo charts
   template: src=service-values.yaml.jinja2
     dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.repo }}-{{ item.name }}.helmvalues"
   with_items: "{{ cluster_services }}"
-  when: cluster_services is defined and (item.repo is defined)
+  when:
+    - cluster_services is defined
+    - item.repo is defined
 
 - name: Save config values to files for registry charts
   template: src=service-values.yaml.jinja2
     dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.registry }}-{{ item.name }}.helmvalues"
   with_items: "{{ cluster_services }}"
-  when: cluster_services is defined and (item.registry is defined)
+  when:
+    - cluster_services is defined
+    - item.registry is defined
 
 - name: Install charts dry-run
   command: >
@@ -120,7 +120,11 @@
     HELM_HOME: "{{ helm_home }}"
   with_items: "{{ cluster_services }}"
   register: install_dry_out
-  when: (cluster_services is defined) and (cluster.helmConfig.debug is defined) and (cluster.helmConfig.debug == True) and (helm_command is defined)
+  when:
+    - cluster_services is defined
+    - cluster.helmConfig.debug is defined
+    - cluster.helmConfig.debug == True
+    - helm_command is defined
 
 - name: Install charts from repo
   command: >
@@ -133,7 +137,10 @@
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
   with_items: "{{ cluster_services }}"
-  when: (cluster_services is defined) and (helm_command is defined) and (item.repo is defined)
+  when:
+    - cluster_services is defined
+    - helm_command is defined
+    - item.repo is defined
 
 - name: Install charts from registry
   command: >
@@ -145,4 +152,7 @@
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
   with_items: "{{ cluster_services }}"
-  when: (cluster_services is defined) and (helm_command is defined) and (item.registry is defined)
+  when:
+    - cluster_services is defined
+    - helm_command is defined
+    - item.registry is defined


### PR DESCRIPTION
This moves duplicated code which uses the found versions to choose which `helm` and `kubectl` executable path to use to configure so it need only be run once.

* Fixes DRY issues
* Fixes linting errors
* Allows for frigid temperatures in the underworld
* Modified `while` `and`s to be lists for readability