### PR TITLE
upgrade services on k2 update

### DIFF
--- a/ansible/roles/kraken.services/tasks/main.yaml
+++ b/ansible/roles/kraken.services/tasks/main.yaml
@@ -29,13 +29,6 @@
     - a_cluster.providerConfig.provider in ['aws']
   static: no
 
-- include: kill-services.yaml
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: a_cluster.helmConfig is defined
-
 - include: run-services.yaml
   with_items:
     - "{{ kraken_config.clusters }}"
@@ -45,3 +38,22 @@
     - kraken_action == 'up'
     - a_cluster.helmConfig is defined
   static: no
+
+- include: manage-services.yaml
+  with_items:
+    - "{{ kraken_config.clusters }}"
+  loop_control:
+    loop_var: a_cluster
+  when:
+    - kraken_action == 'update'
+    - a_cluster.helmConfig is defined
+  static: no
+
+- include: kill-services.yaml
+  with_items:
+    - "{{ kraken_config.clusters }}"
+  loop_control:
+    loop_var: a_cluster
+  when: 
+    - a_cluster.helmConfig is defined
+    - kraken_action == 'down'

--- a/ansible/roles/kraken.services/tasks/main.yaml
+++ b/ansible/roles/kraken.services/tasks/main.yaml
@@ -54,6 +54,6 @@
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: 
+  when:
     - a_cluster.helmConfig is defined
     - kraken_action == 'down'

--- a/ansible/roles/kraken.services/tasks/manage-services.yaml
+++ b/ansible/roles/kraken.services/tasks/manage-services.yaml
@@ -12,6 +12,35 @@
     kubeconfig: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
     helm_home: "{{ config_base | expanduser }}/{{ cluster.name }}/.helm"
 
+- name: Get helm and tiller versions
+  command: >
+    {{ helm_command }} version --short
+  register: helm_versions
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  changed_when: false
+
+- name: Upgrade tiller
+  command: >
+    {{ helm_command }} init --upgrade
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  when:
+    - (helm_versions.stdout_lines | length) == 2
+    - (helm_versions.stdout_lines[0] | regex_replace(regex)) != (helm_versions.stdout_lines[1] | regex_replace(regex))
+  vars:
+    regex: "^.*: "
+
+- name: Wait for tiller to be ready
+  command: "{{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} --namespace=kube-system get deploy tiller-deploy -o json"
+  register: output
+  until: (output | succeeded) and ((output.stdout | from_json).status.availableReplicas | default(0)) > 0
+  retries: 600
+  delay: 1
+  changed_when: false
+
 - name: Remove helm repositories
   command: >
     {{ helm_command }} repo remove {{ item.name }}
@@ -51,14 +80,6 @@
   when:
     - cluster_services is defined
     - item.registry is defined
-
-- name: Collect a list of installed release names
-  command: >
-    {{ helm_command }} list --short
-  environment:
-    KUBECONFIG: "{{ kubeconfig }}"
-    HELM_HOME: "{{ helm_home }}"
-  register: installed_list
 
 - name: Upgrade charts from repo
   command: >

--- a/ansible/roles/kraken.services/tasks/manage-services.yaml
+++ b/ansible/roles/kraken.services/tasks/manage-services.yaml
@@ -1,0 +1,92 @@
+---
+- name: set cluster fact
+  set_fact:
+    cluster: "{{ a_cluster }}"
+
+- name: set facts for run-services
+  set_fact:
+    cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
+    cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
+    helm_command: "{{ helm_commands[cluster.name] }}"
+    kubectl: "{{ kubectl_commands[cluster.name] }}"
+    kubeconfig: "{{ config_base | expanduser }}/{{ cluster.name }}/admin.kubeconfig"
+    helm_home: "{{ config_base | expanduser }}/{{ cluster.name }}/.helm"
+
+- name: Remove helm repositories
+  command: >
+    {{ helm_command }} repo remove {{ item.name }}
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  with_items: "{{ cluster_repos }}"
+  when:
+    - cluster_repos is defined
+    - helm_command is defined
+  ignore_errors: yes
+  failed_when: false
+
+- name: Add helm repositories
+  command: >
+    {{ helm_command }} repo add {{ item.name }} {{ item.url }}
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  with_items: "{{ cluster_repos }}"
+  when:
+    - cluster_repos is defined
+    - helm_command is defined
+
+- name: Save config values to files for repo charts
+  template: src=service-values.yaml.jinja2
+    dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.repo }}-{{ item.name }}.helmvalues"
+  with_items: "{{ cluster_services }}"
+  when:
+    - cluster_services is defined
+    - item.repo is defined
+
+- name: Save config values to files for registry charts
+  template: src=service-values.yaml.jinja2
+    dest="{{ config_base | expanduser }}/{{ cluster.name }}/{{ item.registry }}-{{ item.name }}.helmvalues"
+  with_items: "{{ cluster_services }}"
+  when:
+    - cluster_services is defined
+    - item.registry is defined
+
+- name: Collect a list of installed release names
+  command: >
+    {{ helm_command }} list --short
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  register: installed_list
+
+- name: Upgrade charts from repo
+  command: >
+    {{ helm_command }} upgrade {{ item.name }} {{ item.repo }}/{{ item.chart }}
+      --version {{ item.version }}
+      --namespace {{ item.namespace | default('default') }}
+      --values {{ config_base | expanduser }}/{{ cluster.name }}/{{ item.repo }}-{{ item.name }}.helmvalues
+      --install
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  with_items: "{{ cluster_services }}"
+  when:
+    - cluster_services is defined
+    - helm_command is defined
+    - item.repo is defined
+
+- name: Upgrade charts from registry
+  command: >
+    {{ helm_command }} registry upgrade {{ item.registry }}/{{ item.chart }}@{{ item.version }} {{ item.name }} --
+      --namespace {{ item.namespace | default('default') }}
+      --values {{ config_base | expanduser }}/{{ cluster.name }}/{{ item.registry }}-{{ item.name | replace('/','_') }}.helmvalues
+      --install
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+    HELM_HOME: "{{ helm_home }}"
+  with_items: "{{ cluster_services }}"
+  when:
+    - cluster_services is defined
+    - helm_command is defined
+    - item.registry is defined


### PR DESCRIPTION
Make helm upgrade rather than delete and install.
* Only run kill-services on `down`
* Add `manage-services` to be run on `update` instead
* Upgrade tiller as needed to match helm version

Fixes #453