### PR TITLE
fix missing fi

### DIFF
--- a/bin/max_k8s_version.sh
+++ b/bin/max_k8s_version.sh
@@ -14,6 +14,7 @@ OUTFILE=$1
 if [ -z ${OUTFILE} ]; then 
   echo "must specify a file to save the max version too"
   exit 1
+fi
 if [ ! -f $OUTFILE ]; then
   echo "first arg must be a pre-created file.  should be created with mktemp"
   exit 2


### PR DESCRIPTION
Missing `fi` causes an error if this script is run:
```
bin/max_k8s_version.sh: line 33: syntax error: unexpected end of file
```

This adds the missing `fi`