### PR TITLE
Don't recreate cloud-config if it exists

### DIFF
--- a/ansible/roles/kraken.assembler/tasks/nodes.yaml
+++ b/ansible/roles/kraken.assembler/tasks/nodes.yaml
@@ -23,6 +23,7 @@
     dest_path: "{{ config_base | expanduser }}/{{ cluster.name }}/cloud-config/{{ item.0.name }}.cloud-config.yaml"
   when:
     - ( dest_path | is_file ) == false
+    - item.1.name == "etcd" or item.1.name == "etcdEvvents"
   with_together:
     - "{{ cluster.nodePools }}"
     - "{{ node_list.results }}"

--- a/ansible/roles/kraken.assembler/tasks/nodes.yaml
+++ b/ansible/roles/kraken.assembler/tasks/nodes.yaml
@@ -23,7 +23,7 @@
     dest_path: "{{ config_base | expanduser }}/{{ cluster.name }}/cloud-config/{{ item.0.name }}.cloud-config.yaml"
   when:
     - ( dest_path | is_file ) == false
-    - item.1.name == "etcd" or item.1.name == "etcdEvvents"
+    - item.1.etcdConfig is defined
   with_together:
     - "{{ cluster.nodePools }}"
     - "{{ node_list.results }}"

--- a/ansible/roles/kraken.assembler/tasks/nodes.yaml
+++ b/ansible/roles/kraken.assembler/tasks/nodes.yaml
@@ -18,7 +18,11 @@
 - name: Generate node cloud init
   template:
     src: node.yaml.jinja2
-    dest: "{{ config_base | expanduser }}/{{ cluster.name }}/cloud-config/{{ item.0.name }}.cloud-config.yaml"
+    dest: "{{ dest_path }}"
+  vars:
+    dest_path: "{{ config_base | expanduser }}/{{ cluster.name }}/cloud-config/{{ item.0.name }}.cloud-config.yaml"
+  when:
+    - ( dest_path | is_file ) == false
   with_together:
     - "{{ cluster.nodePools }}"
     - "{{ node_list.results }}"

--- a/ansible/roles/kraken.assembler/tasks/nodes.yaml
+++ b/ansible/roles/kraken.assembler/tasks/nodes.yaml
@@ -22,8 +22,7 @@
   vars:
     dest_path: "{{ config_base | expanduser }}/{{ cluster.name }}/cloud-config/{{ item.0.name }}.cloud-config.yaml"
   when:
-    - ( dest_path | is_file ) == false
-    - item.1.etcdConfig is defined
+    - ( dest_path | is_file ) == false or not (item.1.etcdConfig is defined)
   with_together:
     - "{{ cluster.nodePools }}"
     - "{{ node_list.results }}"


### PR DESCRIPTION
Appending files does so in a random order. This causes a change to the
cloud-config which will cause all the ASG to get recreated. This is
undesired behavior so avoid changing cloud-config.