### PR TITLE
fixed confusing typo in command line prompt

### DIFF
--- a/ansible/roles/kraken.config/tasks/check-update.yaml
+++ b/ansible/roles/kraken.config/tasks/check-update.yaml
@@ -77,7 +77,7 @@
 
 - name: Fail if nodepools were added to config but not specified
   fail:
-    msg: "It looks like you were trying to add the nodepool {{ item }}, but you need to specify this change in your update command, for example: --addnodepool {{ item }}"
+    msg: "It looks like you were trying to add the nodepool {{ item }}, but you need to specify this change in your update command, for example: --addnodepools {{ item }}"
   with_items:
     - "{{ extra_nodepools_in_config }}"
 


### PR DESCRIPTION
This fixes a missing plural in nodepool update error messages. 
@venezia does this help a bit?