### PR TITLE
Use a public team for default reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @coffeepac @davidewatson @mikeln @dstorck @leahnp @yenicapotediaz @guineveresaenger
+*       @samsung-cnct/kraken-reviewers
 
 # Order is important. The last matching pattern has the most precedence.
 /docs/              @davidewatson


### PR DESCRIPTION
three people are in the team right now, I want to see how review requests get allocated.  we can change the team membership if we like how this functions.