### PR TITLE
prevent kraken from removing some kubernetes created resources

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.cluster_secgroup.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.cluster_secgroup.tf.jinja2
@@ -57,7 +57,13 @@ resource "aws_security_group" "vpc_kubernetes_secgroup" {
     Name = "${var.secgroup_name}_vpc_secgroup",
     KubernetesCluster = "${var.secgroup_name}"
   }
-}
+
+{% if kraken_action == 'update' %}
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+{% endif %}
+} 
 
 output "id" {
   value = "${aws_security_group.vpc_kubernetes_secgroup.id}"

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.vpc.tf.jinja2
@@ -69,6 +69,12 @@ resource "aws_route_table" "vpc_rt" {
     Name = "${var.vpc_name}_routetable",
     KubernetesCluster = "${var.vpc_name}"
   }
+  
+{% if kraken_action == 'update' %}
+  lifecycle {
+    ignore_changes = ["route"]
+  }
+{% endif %}
 }
 
 # VPC ACL

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/v1.5/kraken.provider.aws.module.cluster_secgroup.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/v1.5/kraken.provider.aws.module.cluster_secgroup.tf.jinja2
@@ -57,6 +57,12 @@ resource "aws_security_group" "vpc_kubernetes_secgroup" {
     Name = "${var.secgroup_name}_vpc_secgroup",
     KubernetesCluster = "${var.secgroup_name}"
   }
+  
+{% if kraken_action == 'update' %}
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+{% endif %}
 }
 
 output "id" {

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/v1.5/kraken.provider.aws.module.vpc.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/v1.5/kraken.provider.aws.module.vpc.tf.jinja2
@@ -69,6 +69,12 @@ resource "aws_route_table" "vpc_rt" {
     Name = "${var.vpc_name}_routetable",
     KubernetesCluster = "${var.vpc_name}"
   }
+  
+{% if kraken_action == 'update' %}
+  lifecycle {
+    ignore_changes = ["route"]
+  }
+{% endif %}
 }
 
 # VPC ACL

--- a/schemas/config/v1/awsProviderConfig.json
+++ b/schemas/config/v1/awsProviderConfig.json
@@ -66,13 +66,13 @@
       "type": "array"
     },
     "ingressSecurity": {
-      "description": "List of ingress security rules to create for the VPC.",
+      "description": "List of ingress security rules to create for the VPC.  This section is ignored when modifying an existing cluster.",
       "items": { "$ref": "awsSecurityConfig.json" },
       "minItems": 1,
       "type": "array"
     },
     "egressSecurity": {
-      "description": "List of egress security rules to create for the VPC.",
+      "description": "List of egress security rules to create for the VPC.  This section is ignored when modifying an existing cluster.",
       "items": { "$ref": "awsSecurityConfig.json" },
       "minItems": 1,
       "type": "array"


### PR DESCRIPTION
kraken creates the vpc route table and the vpc security group , however
kubernetes will make modifications to both assets as the cluster runs.
we should not let kraken modify either of these resources going forward.

there is no way to specify custom routes in the config file so we are fine there
we need to modify the documentation on the security group to specify that
the ingress and egress rules for the security will only be applied at cluster
creation.

Fixes: #817